### PR TITLE
Add dual-theme styling and local development guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+.DS_Store
+npm-debug.log*
+.vite/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A browser-based football management prototype built with TypeScript, Vite, and a
 
 - 🌍 **Global league world** – Manage any club across the top 10 divisions, with second tiers for the leading six nations and third tiers for the top three.
 - 🏟️ **Club onboarding** – Start each career by choosing your club from a glassmorphic selector. Your choice persists across saves and drives every dashboard view.
+- 🛠️ **Create-a-club** – Found a new team, pick league placement, colours, ambition, and let the game spin up a bespoke squad with budgets shaped by real-world valuations.
 - ⚽ **Seeded simulations** – Deterministic match engine with manual instant-result controls and daily scheduling so careers remain reproducible.
 - 📊 **Dynamic insights** – Standings browser, form trackers, scouting snapshots, and tactical breakdowns updated as you progress through the season.
 - 🤝 **Transfers & finances** – Market listings, bid flows, wage budgets, and club finances that update in real time.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# HTML5-Games
-Random HTML5 Game projects.
+# HTML5 Football Manager
+
+A browser-based football management prototype built with TypeScript, Vite, and a canvas-driven UI. The project focuses on deterministic simulations, rich squad data, and a sleek management interface inspired by modern sports titles.
+
+## Getting started
+
+1. Install dependencies: `npm install`
+2. Start the dev server: `npm run dev`
+3. Visit the printed URL (default `http://localhost:5173`) in your browser.
+
+For a detailed walkthrough—including production builds and troubleshooting tips—see [docs/local-development.md](docs/local-development.md).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A browser-based football management prototype built with TypeScript, Vite, and a canvas-driven UI. The project focuses on deterministic simulations, rich squad data, and a sleek management interface inspired by modern sports titles.
 
+## Feature highlights
+
+- ⚽ Official-style Premier League data with 10 authentic clubs and full squads.
+- 🧠 Deterministic match engine with seeded randomness and manual quick-sim controls.
+- 📈 Dynamic standings, form trackers, and dashboard summaries for your chosen club.
+- 🤝 Transfer market with budgets, valuations, and instant bid resolution.
+- 🎨 Dual light/dark themes with a glassmorphic layout optimised for desktop and tablet.
+
 ## Getting started
 
 1. Install dependencies: `npm install`

--- a/README.md
+++ b/README.md
@@ -1,19 +1,62 @@
 # HTML5 Football Manager
 
-A browser-based football management prototype built with TypeScript, Vite, and a canvas-driven UI. The project focuses on deterministic simulations, rich squad data, and a sleek management interface inspired by modern sports titles.
+A browser-based football management prototype built with TypeScript, Vite, and a canvas-driven UI. The simulation focuses on deterministic results, squad building depth, and a slick management layer inspired by modern sports titles.
 
 ## Feature highlights
 
-- ⚽ Official-style Premier League data with 10 authentic clubs and full squads.
-- 🧠 Deterministic match engine with seeded randomness and manual quick-sim controls.
-- 📈 Dynamic standings, form trackers, and dashboard summaries for your chosen club.
-- 🤝 Transfer market with budgets, valuations, and instant bid resolution.
-- 🎨 Dual light/dark themes with a glassmorphic layout optimised for desktop and tablet.
+- 🌍 **Global league world** – Manage any club across the top 10 divisions, with second tiers for the leading six nations and third tiers for the top three.
+- 🏟️ **Club onboarding** – Start each career by choosing your club from a glassmorphic selector. Your choice persists across saves and drives every dashboard view.
+- ⚽ **Seeded simulations** – Deterministic match engine with manual instant-result controls and daily scheduling so careers remain reproducible.
+- 📊 **Dynamic insights** – Standings browser, form trackers, scouting snapshots, and tactical breakdowns updated as you progress through the season.
+- 🤝 **Transfers & finances** – Market listings, bid flows, wage budgets, and club finances that update in real time.
+- 🎨 **Adaptive themes** – Light/dark palettes, gradients, and responsive cards tuned for desktop and tablet play.
 
 ## Getting started
 
-1. Install dependencies: `npm install`
-2. Start the dev server: `npm run dev`
-3. Visit the printed URL (default `http://localhost:5173`) in your browser.
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Run the development server**
+   ```bash
+   npm run dev
+   ```
+   Open the printed URL (defaults to `http://localhost:5173`) in your browser. The app is a single-page experience—no extra backend setup required.
+3. **Build for production**
+   ```bash
+   npm run build
+   ```
+   Output files appear in `dist/` and can be served from any static host.
 
-For a detailed walkthrough—including production builds and troubleshooting tips—see [docs/local-development.md](docs/local-development.md).
+For troubleshooting tips, dependency notes, and environment configuration details, see [docs/local-development.md](docs/local-development.md).
+
+## Project structure
+
+```
+src/
+  app/         # store setup, world bootstrapping, commands
+  core/        # shared math, RNG, scheduler logic
+  data/        # league packs, team definitions, fixtures
+  domain/      # typed models for clubs, players, transfers
+  engine/      # match simulation utilities and schedulers
+  ui/          # screens, components, canvas pitch renderer
+  styles.css   # design tokens and theme definitions
+```
+
+### Key scripts
+
+- `npm run dev` – start the Vite dev server with hot module replacement.
+- `npm run build` – create an optimised production bundle.
+- `npm run preview` – serve the production build locally for smoke testing.
+
+### Tech stack
+
+- **Language:** TypeScript (strict mode)
+- **Bundler:** Vite + ESBuild
+- **State:** Zustand with Immer for mutations
+- **UI:** HTML/CSS with canvas-driven match visualisations
+- **Persistence:** IndexedDB (via lightweight repository utilities)
+
+## Save data
+
+Save games, theme choices, and simulation seeds are stored in the browser. Use the in-app export controls (coming soon) to back up your careers or migrate them to another device.

--- a/docs/html5-football-manager-design.md
+++ b/docs/html5-football-manager-design.md
@@ -1,0 +1,777 @@
+# HTML5 Football Manager: Technical Design and Implementation Guide
+
+## 1) Objectives and Scope
+
+* Single-page, offline-capable football management sim in the browser.
+* Inspiration: long-term squad building, tactics depth, data-driven scouting, dynamic careers.
+* Deterministic simulation with seeded RNG for reproducibility.
+* Modular architecture enabling leagues, data packs, skins, and match engines to be swapped.
+
+---
+
+## 2) Tech Stack
+
+* **Language:** TypeScript (strict mode).
+* **Render:** HTML5 + Canvas (2D), CSS for UI, optional WebGL for future.
+* **State:** Lightweight store (Zustand/vanilla observable pattern).
+* **Persistence:** IndexedDB via idb/LocalForage; backup/export JSON.
+* **Workers:** Web Workers for match simulation and batch sims.
+* **Routing:** Hash-based (no SSR required).
+* **Build:** Vite/ESBuild.
+* **Testing:** Vitest + Playwright.
+* **PWA:** Service Worker for offline play, cached assets and saves.
+
+---
+
+## 3) Project Structure
+
+```
+/src
+  /app           # bootstrap, DI, service locator
+  /core          # math, rng, time, scheduling
+  /data          # league packs, fixtures templates, name pools
+  /domain
+    /club
+    /player
+    /staff
+    /match
+    /finance
+    /transfer
+    /training
+    /scouting
+    /board
+    /competition
+    /ai
+  /engine
+    /sim         # match engine, physics-lite, event model
+    /ai          # opposition AI, recruitment AI
+  /ui
+    /screens     # Dashboard, Squad, Tactics, Scouting, Transfers, Matchday, Finance
+    /components  # reusable UI
+    /charts
+  /persistence   # repositories, save/load, migrations
+  /workers       # matchWorker.ts, batchSimWorker.ts
+  /mods          # skin + data pack loader
+```
+
+---
+
+## 4) Data Model (TypeScript Interfaces)
+
+### Core
+
+```ts
+type ID = string;
+
+interface DateStamp { season: number; week: number; day: number; } // 0-based within season
+interface RNGSeed { s1: number; s2: number; } // for splitmix/xorshift
+
+interface World {
+  seed: RNGSeed;
+  date: DateStamp;
+  leagues: League[];
+  competitions: Competition[];
+  clubs: Club[];
+  players: Player[];
+  staff: StaffMember[];
+  freeAgents: ID[];
+  fixtures: Fixture[];
+  finances: Record<ID, FinanceLedger>;
+  transferList: TransferListing[];
+  inbox: Mail[];
+  settings: Settings;
+  user: UserProfile;
+}
+```
+
+### Player
+
+```ts
+type Foot = "Left" | "Right" | "Both";
+type Position = "GK"|"RB"|"CB"|"LB"|"DM"|"CM"|"AM"|"RW"|"LW"|"ST";
+type PotentialGrade = "E"|"D"|"C"|"B"|"A"|"A+";
+
+interface Attributes {
+  // Technical
+  finishing: number; firstTouch: number; passing: number; crossing: number; dribbling: number;
+  heading: number; tackling: number; marking: number; longShots: number; setPieces: number;
+  // Mental
+  decisions: number; anticipation: number; vision: number; workRate: number; bravery: number;
+  composure: number; offTheBall: number; positioning: number; leadership: number; flair: number;
+  // Physical
+  pace: number; acceleration: number; strength: number; stamina: number; agility: number; jumping: number;
+  // GK
+  handling: number; reflexes: number; aerial: number; distribution: number;
+}
+
+interface Player {
+  id: ID;
+  name: string;
+  age: number; // in years, fractional permitted
+  nationality: string[];
+  height: number; weight: number;
+  foot: Foot;
+  positions: Position[];
+  attributes: Attributes;            // 1..20
+  currentAbility: number;            // CA 1..200
+  potentialAbility: number;          // PA 1..200
+  potentialGrade: PotentialGrade;    // scouting abstraction
+  form: number[];                    // last N matches ratings 1..10
+  morale: number;                    // 0..100
+  condition: number;                 // 0..100
+  sharpness: number;                 // 0..100
+  traits: string[];                  // "Shoots From Distance", etc.
+  personality: { professionalism:number; ambition:number; loyalty:number; pressure:number; };
+  contract: Contract;
+  clubId: ID | null;
+  value: number;                     // estimated market value
+  wageDemand: number;
+  injury?: Injury;
+  suspensionMatches?: number;
+  homegrownFlags: { club:boolean; nation:boolean };
+  hidden: { consistency:number; injuryProneness:number; adaptability:number };
+}
+```
+
+### Club/Staff
+
+```ts
+interface Club {
+  id: ID; name: string; shortName: string; leagueId: ID;
+  rep: number; financesId: ID; trainingFacilities: number; youthFacilities: number;
+  stadium: Stadium; colors: string[]; philosophy: ClubPhilosophy;
+  roster: ID[]; // player ids
+  staff: ID[];  // staff ids
+  tactics: TacticsProfile;
+}
+
+interface StaffMember {
+  id: ID; role: "Manager"|"Assistant"|"Coach"|"Physio"|"Scout"|"DoF"|"Analyst";
+  attributes: StaffAttributes;
+  contract: Contract; clubId: ID | null;
+}
+```
+
+### Contracts/Finance/Transfers
+
+```ts
+interface Contract { clubId: ID; start: DateStamp; end: DateStamp; wagePerWeek: number; bonuses: Bonus[]; releaseClause?: number; }
+interface FinanceLedger { balance: number; ffpWindow: number; wageBudget: number; transferBudget: number; transactions: Transaction[]; }
+interface TransferListing { playerId: ID; askingPrice?: number; listedByClubId: ID; status: "Listed"|"Bids"|"Accepted"|"Sold"|"Withdrawn"; }
+interface Bid { playerId: ID; fromClubId: ID; toClubId: ID; feeFixed: number; addOns?: AddOn[]; wageOffer?: number; contractYears?: number; }
+```
+
+### Competitions/Fixtures/Match
+
+```ts
+interface League { id: ID; name: string; level: number; nation: string; rules: LeagueRules; clubIds: ID[]; }
+interface Competition { id: ID; name: string; type: "League"|"Cup"|"Continental"; rules: CompetitionRules; }
+interface Fixture { id: ID; competitionId: ID; homeId: ID; awayId: ID; date: DateStamp; matchId?: ID; played: boolean; }
+interface Match { id: ID; fixtureId: ID; state: MatchState; events: MatchEvent[]; ratings: Record<ID,number>; stats: MatchTeamStats[]; }
+```
+
+---
+
+## 5) Time and Scheduling
+
+* Discrete daily ticks; weekly bundles for training, finances, scouting.
+* Matchdays invoke Match Engine in Worker; produce `Match` snapshot for UI replay.
+* Scheduler queues:
+
+  * `Daily`: injuries healing, morale drifts, news generation.
+  * `Weekly`: training application, attribute deltas, wage payments.
+  * `Monthly`: budgets reconciliation, board confidence updates.
+  * `Windows`: transfer window open/close, registration checks.
+
+```ts
+type Job = () => void | Promise<void>;
+class Scheduler {
+  enqueue(when: DateStamp, job: Job): void;
+  runDay(world: World): void; // executes due jobs
+}
+```
+
+---
+
+## 6) RNG and Determinism
+
+* SplitMix64/Xoroshiro seeded per Match and per Simulation batch.
+* Do not use `Math.random()`.
+* Seed chain includes world seed + fixture id + minute.
+
+```ts
+interface RNG { next(): number; nextInt(n:number): number; pick<T>(arr:T[]): T; }
+```
+
+---
+
+## 7) Match Engine Overview
+
+### Representation
+
+* 2D abstract pitch coordinates: 0..100 width, 0..100 length.
+* Possession state machine; phases: Build-Up, Transition, Final Third, Set-Piece, Turnover.
+* Event model: `Pass`, `Dribble`, `Shot`, `Tackle`, `Interception`, `Save`, `Foul`, `Card`, `Injury`, `Goal`, `Offside`.
+* Simulation tick: 100ms real-time ~ 5s game-time (configurable).
+
+### Inputs
+
+* Team sheets with roles, mentalities, shape, lines:
+
+  * Formation (e.g., 4-2-3-1).
+  * Team instructions: tempo, width, line height, press intensity, time wasting, passing risk.
+  * Player roles: e.g., `CM(S)`, `CM(D)`, `IW(A)`, `HB(D)`, `AF(A)`.
+  * Set-piece routines.
+
+### Outputs
+
+* Full event log, team and player stats, xG, heatmaps, momentum, ratings 1..10.
+
+### Core Loop (Worker)
+
+```ts
+function simulateMatch(input: MatchInput, seed: RNGSeed): Match {
+  const rng = createRNG(seed);
+  const ctx = initContext(input, rng);
+  for (let t = 0; t < input.totalSeconds; t += ctx.delta) {
+    advanceFatigue(ctx);
+    maybeAdjustAI(ctx, rng);           // opposition tweaks
+    stepPhase(ctx, rng);               // generates events
+    if (shouldStopForSetPiece(ctx)) runSetPiece(ctx, rng);
+    if (shouldApplySub(ctx)) applySub(ctx);
+    if (isHalfTime(t)) halfTimeAdjust(ctx, rng);
+  }
+  finalizeRatings(ctx);
+  return toMatch(ctx);
+}
+```
+
+### Event Resolution Examples
+
+```ts
+// Pass success probability
+function passSuccess(passer: Player, difficulty: number, ctx: Ctx): number {
+  const tech = passer.attributes.passing * 0.6 + passer.attributes.vision * 0.4;
+  const pressure = ctx.defPressFactor; // 0..1
+  const fatigue = 1 - passer.condition/100;
+  const tempo = ctx.teamInstr.tempo; // increases error
+  const base = clamp(0.15 + (tech/20)*0.75 - difficulty*0.3 - pressure*0.2 - fatigue*0.25 - tempo*0.05, 0.05, 0.95);
+  return base;
+}
+
+// Shot xG model
+function expectedGoalProb(shooter: Player, shot: ShotContext): number {
+  const base = shotModel(shot.distance, shot.angle, shot.bodyPart, shot.pressure); // learnt or hardcoded
+  const fin = shooter.attributes.finishing/20;
+  const comp = shooter.attributes.composure/20;
+  return clamp(base * (0.6 + 0.6*fin) * (0.7 + 0.5*comp), 0.01, 0.99);
+}
+```
+
+### Ratings
+
+* Baseline 6.5 adjusted by contributions:
+
+  * Positive: key passes, progressive actions, xG+xA contribution, defensive wins, distance covered vs role demand.
+  * Negative: errors leading to shots/goals, misplaced passes weighted by zone, fouls, low work rate.
+
+---
+
+## 8) Tactics System
+
+### Team Instructions
+
+* Mentality: `Very Defensive … Very Attacking` maps to risk multipliers.
+* Tempo, Width, Defensive Line, Line of Engagement, Press intensity, Time Wasting.
+* In possession: overlaps/underlaps, focus flanks/through middle, passing directness.
+* In transition: counter/counter-press, regroup, GK distribution.
+* Out of possession: trap inside/outside, tighter marking.
+
+### Player Roles
+
+* Role archetypes with behaviour vectors per phase: `support`, `attack`, `defend` weights and space occupation.
+* Example role spec:
+
+```ts
+interface RoleBehaviour {
+  supportZones: PitchZone[]; attackRuns: RunPattern[]; pressTendency: number;
+  passingRisk: number; crossingFreq: number; shotFreq: number; holdBall: boolean;
+}
+```
+
+### In-Match Adjustments
+
+* Quick presets and granular sliders apply to engine context immediately.
+* Opposition instructions target key attributes of opponents.
+
+---
+
+## 9) AI Manager
+
+### Tactical AI
+
+* Opponent scouts your recent matches (rolling stats) and generates plan vs your weaknesses.
+* Bayesian switch policy during match based on xG differential, momentum, red cards, fatigue.
+
+### Recruitment AI
+
+* Profiles by club philosophy and budget.
+* Shortlists naive + heuristic + Monte Carlo expected value:
+
+  * `EV = ContributionValue(seasons) − TransferCost − Wages + ResaleValue`.
+* Negotiation tactics simulate walk-away, clauses, overpayment risk.
+
+---
+
+## 10) Transfers and Contracts
+
+### Valuation
+
+* Base value from CA/PA, age curve, contract length, position scarcity, league reputation.
+* Injury proneness and consistency discount.
+
+```ts
+value = leagueCoef * (CA^1.6) * ageCurve(age) * (1 + PA/200*0.2) * contractFactor(monthsLeft) * positionCoef * healthCoeff
+```
+
+### Negotiation State Machine
+
+* States: `Initial → Counter → Optional Clauses → Accept | Decline | Timeout`.
+* Clauses: sell-on %, appearance bonuses, goals/assists, promotion, minimum fee (domestic/foreign), relegation cut.
+
+### Work Permits/Registration
+
+* Rule validators injected per league (non-EU limits, homegrown quotas).
+
+---
+
+## 11) Training and Development
+
+### Weekly Plan
+
+* Team schedules: Physical/Technical/Tactical/Recovery slots with intensity.
+* Individual focuses and role training.
+* Attribute deltas:
+
+```ts
+delta = baseRate * facilityCoef * staffCoef * playerTraitCoef * intensityCoef
+delta *= fatiguePenalty(condition) * ageCurve(age) * injuryPenalty
+```
+
+### Progression
+
+* PA cap with stochastic breakthroughs/backslides influenced by professionalism, ambition, game time.
+
+---
+
+## 12) Scouting and Recruitment
+
+### Knowledge Model
+
+* Each report has `certainty 0..1`; fog reduces to banded grades.
+* Assignments by region, competition, role archetype, or shortlist watch.
+
+### Newgens/Regens
+
+* Annual youth intake per club/nation seeded by youth rating; names from locale pools; PA distribution shaped by nation.
+
+---
+
+## 13) Squad Dynamics and Morale
+
+* Social groups, hierarchy (captain/vice), promises, playing time expectations.
+* Morale changes: results, praise/criticism, contracts, training workload, media handling.
+* Board confidence tracks: results, finance, philosophy compliance, match style.
+
+---
+
+## 14) Competitions and Fixtures
+
+* Rule schemas: points, tiebreakers, squad registration cutoffs, foreign limits, transfer windows.
+* Fixture generator: round-robin, Swiss-style, cup with seeding.
+* Congestion handler and postponements for weather or continental travel.
+
+---
+
+## 15) Finance and FFP
+
+* Revenue streams: matchday, broadcasting, prize, sponsorship, sales.
+* Costs: wages, amortization, bonuses, operations.
+* FFP window rolling profit/loss with sanctions.
+
+```ts
+amortizationPerYear = transferFee / contractYears
+wageToTurnover = totalWages / totalRevenue
+```
+
+---
+
+## 16) UI Architecture
+
+### Screens
+
+* **Dashboard:** fixtures, injuries, training summary, transfer alerts, board confidence, finances sparkline.
+* **Squad:** table with filters, role view, condition/morale, selection helpers.
+* **Tactics:** formation canvas on Grid; drag-drop roles/instructions; set-piece editor.
+* **Training:** calendar grid; intensity sliders; coach assignment.
+* **Scouting:** assignments board, shortlist, player cards with banded attributes and certainty bars.
+* **Transfers:** market list, bids inbox, negotiation modal.
+* **Matchday:** canvas pitch, event timeline, stats tabs, heatmaps, momentum graph, quick shouts.
+* **Finance:** ledger, budgets, projections, compliance.
+* **Board/Club:** objectives, philosophies, promises, facility upgrades.
+
+### Components
+
+* DataGrid, Badge, ProgressBar, Sparkline, Radar chart for attributes, RolePicker, FormationPicker, ClauseEditor.
+
+---
+
+## 17) State Management
+
+* Immutable world snapshots per day boundary for rollback/debug.
+* UI derives from selectors; no component mutates world directly.
+* Command pattern for actions:
+
+```ts
+interface Command { type:string; payload:any; }
+dispatch({type:"TRANSFER_BID_SUBMIT", payload:{ playerId, fromClubId, offer }});
+```
+
+---
+
+## 18) Persistence and Migrations
+
+* Save slots: meta + chunked world JSON.
+* Compress with LZ-string before IndexedDB write.
+* Semantic versioned schema; migration pipeline applies on load.
+
+---
+
+## 19) Performance
+
+* Web Worker handles match sim, training batch, fixture generation.
+* Canvas layers: pitch/static, players, ball, overlays; requestAnimationFrame loop decoupled from sim tick.
+* Virtualized tables for large datasets.
+* Memoized selectors for derived stats.
+
+---
+
+## 20) Security/Cheating
+
+* Hash world state with seed salt to detect edits (for achievements only).
+* Dev tools gated by flag; export/import signed with checksum.
+
+---
+
+## 21) Internationalization
+
+* i18n keys for UI strings; locale date/number formats; league packs localized names.
+* Name pools per culture for regen generation.
+
+---
+
+## 22) Modding/Data Packs
+
+* JSON schema for nations, leagues, clubs, players, kits, rules.
+* Skin system: CSS variables + component theme tokens.
+* Safe sandbox: validate pack schema before import.
+
+---
+
+## 23) Analytics/Telemetry (Local)
+
+* Local opt-in: match length, fps, sim ms per tick; no remote by default.
+* Debug overlay: sim speed, queued events, worker lag.
+
+---
+
+## 24) Minimal Implementable Slice (MIS)
+
+1. World bootstrap with one league, 10 clubs, synthetic players.
+2. Daily scheduler; fixtures; simple 2D match sim producing score + basic stats.
+3. Squad screen; Tactics with formation and 3 global sliders; Transfers disabled.
+4. Save/load; PWA offline.
+5. Tests for match determinism and scheduler.
+
+---
+
+## 25) Key Algorithms (Pseudocode)
+
+### Team Selection
+
+```ts
+function pickXI(club: Club): ID[] {
+  const roles = formationToRoles(club.tactics.formation);
+  return roles.map(r => bestFit(club.roster, r));
+}
+```
+
+### Fitness and Fatigue
+
+```ts
+function advanceFatigue(ctx: Ctx) {
+  for (const p of ctx.onPitch) {
+    const workload = roleWorkload(p.role, ctx.instructions);
+    const press = ctx.instructions.pressIntensity;
+    p.condition -= clamp( baseDrop(workload, press) * (1 + (100 - p.attributes.stamina)/140), 0, 1.2 );
+    p.sharpness += matchSharpnessGain(p);
+  }
+}
+```
+
+### Injury Probability
+
+```ts
+P(injury) = base * workload * (1 + hidden.injuryProneness/20) * (1 - condition/100) * congestionFactor
+```
+
+### Transfer Bid Acceptance
+
+```ts
+accept = feeFixed >= value * demandCoef && (clauses acceptable) && not keyPlayerUnlessReplacement
+```
+
+### Player Progression Weekly
+
+```ts
+for each attribute a:
+  delta = (trainingFocus[a] ? 1.2 : 0.8) * facilities * coachQuality * professionalismCoef * minutesPlayedCoef
+  player.attributes[a] = clamp(player.attributes[a] + gaussian(delta, sigma), 1, 20)
+  adjust CA with total attribute energy, cap by PA
+```
+
+### Scouting Certainty Update
+
+```ts
+certainty += min(1, (scoutAbility * hoursObserved) / targetThreshold) * regionFamiliarity
+```
+
+---
+
+## 26) API Contracts (Selected)
+
+### Match Worker
+
+```ts
+// main thread
+worker.postMessage({ type:"RUN_MATCH", input: matchInput, seed });
+
+// worker
+onmessage = (e) => {
+  if (e.data.type === "RUN_MATCH") {
+    const result = simulateMatch(e.data.input, e.data.seed);
+    postMessage({ type:"MATCH_DONE", result });
+  }
+};
+```
+
+### Repository
+
+```ts
+interface SaveRepository {
+  save(slot: string, world: World): Promise<void>;
+  load(slot: string): Promise<World>;
+  list(): Promise<SaveMeta[]>;
+}
+```
+
+---
+
+## 27) UI/UX Details
+
+* Keyboard navigation across squad table, bulk actions, filters.
+* Tactics board with snap-to-lanes; tooltips show role behaviours and demanded attributes.
+* Matchday: pause, speed x1/x2/x4; instant result; post-match analytics with xG plot and pass networks.
+* Dark/light themes; high-contrast mode.
+
+---
+
+## 28) KPIs for Simulation Quality
+
+* Correlation of team strength vs points ~0.7–0.85 over seasons.
+* Goals per match ~2.4–3.1 depending on league rules and tactics.
+* Shot conversion ~9–13%; pass accuracy midfield 78–88%; press intensity impacts turnovers by ±10–20%.
+* Variance controlled by seeded randomness; repeatable outcomes from same seed.
+
+---
+
+## 29) Testing Protocol
+
+* Unit tests: valuation, injury calc, xG model bounds, training deltas, registration rules.
+* Property tests: no negative balances after monthly reconcile; fixtures cover all pairs in round-robin.
+* Golden tests: given seed + lineups, exact event sequence hash must match.
+* UI tests: negotiation modal flows; drag-drop tactics; save/load.
+
+---
+
+## 30) Roadmap
+
+* **v0.1** MIS + save/load + single league + instant result.
+* **v0.2** Full match visualizer + set-pieces + basic transfers.
+* **v0.3** Training planner + injuries + squad dynamics.
+* **v0.4** Multi-league pyramid + promotions/relegations + registrations.
+* **v0.5** Cups + continental comps + media/inbox + board confidence.
+* **v1.0** Modding, skins, full scouting network, data import, achievements.
+
+---
+
+## 31) Example Type Definitions and Utilities
+
+```ts
+// Attribute helper
+export function attribScore(p: Player, weights: Partial<Record<keyof Attributes, number>>): number {
+  let s = 0, w = 0;
+  for (const k in weights) { const wk = weights[k as keyof Attributes] ?? 0; s += (p.attributes[k as keyof Attributes] || 0) * wk; w += wk; }
+  return w ? s / w : 0;
+}
+
+// Role fit
+const roleWeights = {
+  "CM(S)": { passing:3, vision:2, decisions:2, stamina:2, firstTouch:1, workRate:2, positioning:1 },
+  "IW(A)": { dribbling:3, pace:2, acceleration:2, crossing:2, flair:2, offTheBall:2, finishing:1 },
+  "AF(A)": { finishing:3, offTheBall:3, pace:2, acceleration:2, composure:2, firstTouch:2, strength:1 },
+} as const;
+
+// Rating aggregator
+function computeRating(ctx: PlayerMatchCtx): number {
+  let r = 6.5;
+  r += 0.3 * ctx.keyPasses + 0.4 * ctx.tacklesWon + 0.5 * ctx.interceptions;
+  r += 0.8 * ctx.goals + 0.5 * ctx.assists + 0.1 * (ctx.xG + ctx.xA);
+  r -= 0.6 * ctx.errorsLeadToShot - 0.9 * ctx.errorsLeadToGoal;
+  r += clamp((ctx.distanceCovered / ctx.roleDemand) - 1, -0.5, 0.5);
+  return clamp(r, 1, 10);
+}
+```
+
+---
+
+## 32) Minimal HTML/Canvas Skeleton
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>HTML5 Football Manager</title>
+  <style>
+    html,body,#app{height:100%;margin:0}
+    .layout{display:grid;grid-template-columns:280px 1fr;grid-template-rows:56px 1fr;grid-template-areas:"nav header" "nav main";height:100%}
+    nav{grid-area:nav;border-right:1px solid #ddd;overflow:auto}
+    header{grid-area:header;border-bottom:1px solid #ddd;display:flex;align-items:center;padding:0 12px}
+    main{grid-area:main;overflow:auto}
+    canvas{width:100%;height:360px;border:1px solid #ddd}
+  </style>
+</head>
+<body>
+<div id="app" class="layout">
+  <nav>
+    <button data-view="dashboard">Dashboard</button>
+    <button data-view="squad">Squad</button>
+    <button data-view="tactics">Tactics</button>
+    <button data-view="match">Match</button>
+  </nav>
+  <header><strong id="title">Dashboard</strong></header>
+  <main id="view"></main>
+</div>
+<script type="module">
+  const state = { view: "dashboard" };
+  const view = document.getElementById("view"), title = document.getElementById("title");
+  document.querySelectorAll("nav button").forEach(b=>b.onclick=()=>render(b.dataset.view));
+  function render(v){
+    state.view=v; title.textContent=v[0].toUpperCase()+v.slice(1);
+    if(v==="match"){ view.innerHTML=`<canvas id="pitch" width="900" height="360"></canvas>`; drawPitch(); }
+    else if(v==="tactics"){ view.innerHTML=`<div>Formation editor placeholder</div>`; }
+    else if(v==="squad"){ view.innerHTML=`<div>Squad table placeholder</div>`; }
+    else { view.innerHTML=`<div>Dashboard placeholder</div>`; }
+  }
+  function drawPitch(){
+    const c = document.getElementById("pitch"); const ctx = c.getContext("2d");
+    ctx.fillStyle="#0b7a2a"; ctx.fillRect(0,0,c.width,c.height);
+    ctx.strokeStyle="#fff"; ctx.lineWidth=2;
+    ctx.strokeRect(10,10,c.width-20,c.height-20);
+    ctx.beginPath(); ctx.moveTo(c.width/2,10); ctx.lineTo(c.width/2,c.height-10); ctx.stroke();
+    ctx.beginPath(); ctx.arc(c.width/2,c.height/2,60,0,Math.PI*2); ctx.stroke();
+  }
+  render("dashboard");
+</script>
+</body>
+</html>
+```
+
+---
+
+## 33) Save Format Outline
+
+```json
+{
+  "version":"1.0.0",
+  "seed":{"s1":123,"s2":456},
+  "date":{"season":2025,"week":12,"day":4},
+  "clubs":[/*...*/],
+  "players":[/*...*/],
+  "fixtures":[/*...*/],
+  "finances":{/*...*/},
+  "settings":{"difficulty":"Standard","simSpeed":2}
+}
+```
+
+---
+
+## 34) Data Import Schema (Mods)
+
+```json
+{
+  "$schema":"https://example.com/fm/schema.json",
+  "nations":[{"code":"NL","name":"Netherlands","youthRating":140}],
+  "leagues":[{"id":"eredivisie","nation":"NL","level":1,"rules":{"foreignLimit":null}}],
+  "clubs":[{"id":"ajax","leagueId":"eredivisie","name":"AFC Ajax","rep":8200}],
+  "players":[{"id":"p1","clubId":"ajax","name":"J. Doe","age":19,"positions":["CM"],"CA":95,"PA":160}]
+}
+```
+
+---
+
+## 35) Build Targets
+
+* Desktop Chrome/Edge/Firefox latest; touch-friendly layouts for tablets.
+* 60 FPS render target on matchday; sim at fixed timestep capped to 5x.
+
+---
+
+## 36) Accessibility
+
+* Keyboard first navigation, skip links.
+* ARIA roles for grids and tabs.
+* Color-blind safe palettes for kits and event highlights.
+
+---
+
+## 37) Deployment
+
+* Static hosting (Netlify/Vercel/GitHub Pages).
+* Cache busting via hashed assets.
+* Service Worker pre-cache plus runtime caching for saves.
+
+---
+
+## 38) Versioning and Compatibility
+
+* SemVer for save schema and engine.
+* Migrations per minor; major may break match replay compatibility while preserving career data.
+
+---
+
+## 39) Telemetry for Balancing (Local Only)
+
+* Export anonymized CSV of season aggregates: goals, cards, pass %, shot maps.
+* Tools to tune coefficients and rerun season sims with fixed seed batches.
+
+---
+
+## 40) Exit Criteria for v1.0
+
+* 10+ season careers without softlocks.
+* AI squads maintain role coverage and wage sanity.
+* Transfer markets exhibit realistic fees and wage inflation.
+* Tactical choices measurably change event profiles and outcomes.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,61 @@
+# Running HTML5 Football Manager Locally
+
+Follow these steps to set up the project on your machine and start iterating on the game.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) **18.0.0 or later** (Vite 5 requires Node 18+).
+- npm (bundled with Node.js).
+
+Check your versions:
+
+```bash
+node --version
+npm --version
+```
+
+## Install dependencies
+
+From the repository root, install the project dependencies:
+
+```bash
+npm install
+```
+
+This will fetch TypeScript, Vite, and other tooling specified in `package.json`.
+
+## Start the development server
+
+Launch Vite's dev server with hot module replacement:
+
+```bash
+npm run dev
+```
+
+The terminal will print a local URL (typically `http://localhost:5173`). Open it in your browser to see the game. Changes to TypeScript, HTML, or CSS files will automatically trigger a reload.
+
+## Build for production
+
+Generate an optimized production build:
+
+```bash
+npm run build
+```
+
+This command type-checks the code and emits static assets in the `dist/` folder.
+
+## Preview the production build
+
+Serve the built assets locally to verify the production output:
+
+```bash
+npm run preview
+```
+
+This runs a static server backed by the `dist/` directory. Stop the server with `Ctrl+C` when you're done.
+
+## Troubleshooting
+
+- Delete `node_modules` and run `npm install` again if dependency issues appear.
+- Ensure no other process is using the dev server port (`5173` by default).
+- Use a modern Chromium, Firefox, or WebKit-based browser for the best experience.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HTML5 Football Manager</title>
+    <link rel="stylesheet" href="src/styles.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="src/main.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,957 @@
+{
+  "name": "html5-football-manager",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "html5-football-manager",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.4.5",
+        "vite": "^5.2.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,12 @@
     "": {
       "name": "html5-football-manager",
       "version": "0.1.0",
+      "dependencies": {
+        "date-fns": "^3.6.0",
+        "immer": "^10.1.1",
+        "nanoid": "^5.0.7",
+        "zustand": "^4.5.2"
+      },
       "devDependencies": {
         "typescript": "^5.4.5",
         "vite": "^5.2.0"
@@ -718,6 +724,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -772,11 +788,20 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
       "funding": [
         {
           "type": "github",
@@ -785,10 +810,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/picocolors": {
@@ -825,6 +850,35 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -893,6 +947,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "5.4.20",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
@@ -949,6 +1012,34 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
+  "dependencies": {
+    "date-fns": "^3.6.0",
+    "immer": "^10.1.1",
+    "nanoid": "^5.0.7",
+    "zustand": "^4.5.2"
+  },
   "devDependencies": {
     "typescript": "^5.4.5",
     "vite": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "html5-football-manager",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,0 +1,56 @@
+import { createInitialWorld, simulateDay, type DailyTickSummary, type World } from "@app/world";
+import type { RNGSeed } from "@core/types";
+
+type Listener = () => void;
+
+type WorldCommand =
+  | { type: "ADVANCE_DAY" }
+  | { type: "ADVANCE_DAYS"; payload: { days?: number } };
+
+export class GameStore {
+  private state: World;
+  private listeners: Set<Listener> = new Set();
+
+  constructor(seed: RNGSeed) {
+    this.state = createInitialWorld(seed);
+  }
+
+  get snapshot(): World {
+    return this.state;
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  dispatch(command: WorldCommand): DailyTickSummary | null {
+    switch (command.type) {
+      case "ADVANCE_DAY": {
+        const summary = simulateDay(this.state);
+        this.notify();
+        return summary;
+      }
+      case "ADVANCE_DAYS": {
+        const days = command.payload?.days ?? 7;
+        let lastSummary: DailyTickSummary | null = null;
+        for (let i = 0; i < days; i += 1) {
+          lastSummary = simulateDay(this.state);
+        }
+        this.notify();
+        return lastSummary;
+      }
+      default:
+        return null;
+    }
+  }
+
+  private notify(): void {
+    this.listeners.forEach((listener) => listener());
+  }
+}
+
+export function randomSeed(): RNGSeed {
+  const now = Date.now();
+  return { s1: now & 0xffffffff, s2: (now >> 32) & 0xffffffff };
+}

--- a/src/app/world.ts
+++ b/src/app/world.ts
@@ -1,0 +1,246 @@
+import { createRNG, deriveSeed, type RNG } from "@core/rng";
+import { nextDay } from "@core/types";
+import type { DateStamp, ID, RNGSeed } from "@core/types";
+import type { Club, League } from "@domain/club/types";
+import type { Player, Position } from "@domain/player/types";
+import type { Fixture, Match } from "@domain/match/types";
+import { buildSchedule } from "@engine/sim/schedule";
+import { simulateMatch } from "@engine/sim/simpleMatch";
+
+export interface World {
+  seed: RNGSeed;
+  date: DateStamp;
+  leagues: League[];
+  clubs: Club[];
+  players: Player[];
+  fixtures: Fixture[];
+  matches: Match[];
+  inbox: string[];
+  results: Match[];
+  userClubId: ID;
+}
+
+export interface DailyTickSummary {
+  matches: Match[];
+  messages: string[];
+}
+
+export function createInitialWorld(seed: RNGSeed): World {
+  const rng = createRNG(seed);
+  const league: League = {
+    id: "league-1",
+    name: "Founders League",
+    nation: "Neutral",
+    clubIds: [],
+    level: 1
+  };
+
+  const clubs: Club[] = Array.from({ length: 10 }, (_, idx) => {
+    const id = `club-${idx + 1}`;
+    league.clubIds.push(id);
+    return {
+      id,
+      name: `FC ${cityNames[idx % cityNames.length]}`,
+      shortName: `FC${idx + 1}`,
+      leagueId: league.id,
+      roster: [],
+      colors: [accentPalette[idx % accentPalette.length]],
+      tactics: {
+        formation: formations[idx % formations.length],
+        mentality: rng.pick(["Balanced", "Positive", "Cautious"]),
+        tempo: 50 + rng.nextInt(50),
+        press: 50 + rng.nextInt(50)
+      },
+      rep: 3000 + rng.nextInt(2000)
+    };
+  });
+
+  const players: Player[] = [];
+  clubs.forEach((club) => {
+    const rosterSize = 18;
+    for (let i = 0; i < rosterSize; i += 1) {
+      const id = `${club.id}-player-${i}`;
+      const position = defaultFormationOrder[i % defaultFormationOrder.length];
+      const currentAbility = 40 + Math.floor(rng.next() * 40);
+      const player: Player = {
+        id,
+        name: `${rng.pick(firstNames)} ${rng.pick(lastNames)}`,
+        age: 18 + Math.floor(rng.next() * 15),
+        nationality: rng.pick(["ENG", "ESP", "GER", "BRA", "ARG", "FRA", "NED"]),
+        foot: rng.pick(["Left", "Right", "Both"]),
+        positions: [position],
+        attributes: generateAttributes(rng, position, currentAbility),
+        currentAbility,
+        potentialAbility: currentAbility + 20 + Math.floor(rng.next() * 60),
+        morale: 60 + Math.floor(rng.next() * 40),
+        condition: 70 + Math.floor(rng.next() * 30),
+        sharpness: 40 + Math.floor(rng.next() * 60),
+        value: currentAbility * 25000,
+        clubId: club.id,
+        form: []
+      };
+      players.push(player);
+      club.roster.push(player.id);
+    }
+  });
+
+  const fixtures = buildSchedule(clubs, league.id, { season: 2025, week: 0, day: 0 });
+
+  return {
+    seed,
+    date: { season: 2025, week: 0, day: 0 },
+    leagues: [league],
+    clubs,
+    players,
+    fixtures,
+    matches: [],
+    inbox: ["Welcome to HTML5 Football Manager!"],
+    results: [],
+    userClubId: clubs[0].id
+  };
+}
+
+export function simulateDay(world: World): DailyTickSummary {
+  const todaysFixtures = world.fixtures.filter(
+    (fixture) => !fixture.played && sameDate(fixture.date, world.date)
+  );
+
+  const rngSeed = deriveSeed(world.seed, world.date.week * 10 + world.date.day);
+  const matches: Match[] = todaysFixtures.map((fixture) => simulateMatch(world, fixture, rngSeed));
+
+  matches.forEach((match) => {
+    world.matches.push(match);
+    world.results.unshift(match);
+    const fixture = world.fixtures.find((f) => f.id === match.fixtureId);
+    if (fixture) {
+      fixture.played = true;
+      fixture.matchId = match.id;
+    }
+  });
+
+  const messages = todaysFixtures.length
+    ? todaysFixtures.map((f) =>
+        `${clubName(world, f.homeId)} ${scoreLine(world, f.matchId)} ${clubName(world, f.awayId)}`
+      )
+    : ["No matches today."];
+
+  world.date = nextDay(world.date);
+
+  return { matches, messages };
+}
+
+function sameDate(a: DateStamp, b: DateStamp): boolean {
+  return a.season === b.season && a.week === b.week && a.day === b.day;
+}
+
+function clubName(world: World, id: ID): string {
+  return world.clubs.find((c) => c.id === id)?.shortName ?? "Unknown";
+}
+
+function scoreLine(world: World, matchId?: ID): string {
+  if (!matchId) return "vs";
+  const match = world.matches.find((m) => m.id === matchId);
+  if (!match) return "vs";
+  return `${match.score.home}-${match.score.away}`;
+}
+
+function generateAttributes(rng: RNG, position: string, ability: number) {
+  const base = ability / 5;
+  const randomAttribute = () => Math.max(1, Math.min(20, Math.round(base + rng.next() * 4)));
+  return {
+    finishing: randomAttribute(),
+    firstTouch: randomAttribute(),
+    passing: randomAttribute(),
+    crossing: randomAttribute(),
+    dribbling: randomAttribute(),
+    heading: randomAttribute(),
+    tackling: randomAttribute(),
+    marking: randomAttribute(),
+    longShots: randomAttribute(),
+    setPieces: randomAttribute(),
+    decisions: randomAttribute(),
+    anticipation: randomAttribute(),
+    vision: randomAttribute(),
+    workRate: randomAttribute(),
+    bravery: randomAttribute(),
+    composure: randomAttribute(),
+    offTheBall: randomAttribute(),
+    positioning: randomAttribute(),
+    leadership: randomAttribute(),
+    flair: randomAttribute(),
+    pace: randomAttribute(),
+    acceleration: randomAttribute(),
+    strength: randomAttribute(),
+    stamina: randomAttribute(),
+    agility: randomAttribute(),
+    jumping: randomAttribute(),
+    handling: position === "GK" ? randomAttribute() : 1,
+    reflexes: position === "GK" ? randomAttribute() : 1,
+    aerial: position === "GK" ? randomAttribute() : randomAttribute(),
+    distribution: position === "GK" ? randomAttribute() : randomAttribute()
+  };
+}
+
+const cityNames = [
+  "Avalon",
+  "Rivermouth",
+  "Highfield",
+  "Kingsport",
+  "Northhaven",
+  "Silverbrook",
+  "Westminster",
+  "Greenwich",
+  "Brighton",
+  "Southport"
+];
+
+const firstNames = [
+  "Alex",
+  "Luis",
+  "Noah",
+  "Leo",
+  "Mateo",
+  "Mason",
+  "Ethan",
+  "Kai",
+  "Luca",
+  "Owen"
+];
+
+const lastNames = [
+  "Santos",
+  "Garcia",
+  "Fischer",
+  "Johnson",
+  "Silva",
+  "Martinez",
+  "Okafor",
+  "Nguyen",
+  "Ito",
+  "Kouadio"
+];
+
+const accentPalette = ["#3ecf8e", "#60a5fa", "#f97316", "#a855f7", "#facc15"];
+
+const formations = ["4-4-2", "4-3-3", "3-5-2"];
+
+const defaultFormationOrder: Position[] = [
+  "GK",
+  "RB",
+  "CB",
+  "CB",
+  "LB",
+  "CM",
+  "CM",
+  "AM",
+  "RW",
+  "LW",
+  "ST",
+  "ST",
+  "DM",
+  "CB",
+  "CM",
+  "LW",
+  "RW",
+  "ST"
+];

--- a/src/core/rng.ts
+++ b/src/core/rng.ts
@@ -1,0 +1,64 @@
+import type { RNGSeed } from "./types";
+
+export interface RNG {
+  next(): number;
+  nextInt(max: number): number;
+  pick<T>(items: readonly T[]): T;
+}
+
+function rotl(x: bigint, k: bigint): bigint {
+  return ((x << k) | (x >> (64n - k))) & ((1n << 64n) - 1n);
+}
+
+function splitMix64(seed: bigint): () => bigint {
+  let state = seed & ((1n << 64n) - 1n);
+  return () => {
+    state = (state + 0x9e3779b97f4a7c15n) & ((1n << 64n) - 1n);
+    let z = state;
+    z = (z ^ (z >> 30n)) * 0xbf58476d1ce4e5b9n & ((1n << 64n) - 1n);
+    z = (z ^ (z >> 27n)) * 0x94d049bb133111ebn & ((1n << 64n) - 1n);
+    return z ^ (z >> 31n);
+  };
+}
+
+export function createRNG(seed: RNGSeed): RNG {
+  const sm = splitMix64(BigInt(seed.s1) << 32n | BigInt(seed.s2));
+  let s0 = sm();
+  let s1 = sm();
+
+  const nextRaw = () => {
+    const result = rotl(s0 + s1, 17n) + s0;
+    s1 ^= s0;
+    s0 = rotl(s0, 49n) ^ s1 ^ (s1 << 21n);
+    s1 = rotl(s1, 28n);
+    return Number(result & ((1n << 64n) - 1n));
+  };
+
+  return {
+    next(): number {
+      return (nextRaw() >>> 0) / 0x1_0000_0000;
+    },
+    nextInt(max: number): number {
+      if (max <= 0) {
+        throw new Error("max must be positive");
+      }
+      return Math.floor(this.next() * max);
+    },
+    pick<T>(items: readonly T[]): T {
+      if (!items.length) {
+        throw new Error("cannot pick from empty array");
+      }
+      return items[this.nextInt(items.length)];
+    }
+  };
+}
+
+export function deriveSeed(seed: RNGSeed, salt: number): RNGSeed {
+  const rng = createRNG(seed);
+  for (let i = 0; i < salt % 5; i += 1) {
+    rng.next();
+  }
+  const s1 = Math.floor(rng.next() * 0xffffffff);
+  const s2 = Math.floor(rng.next() * 0xffffffff);
+  return { s1, s2 };
+}

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -1,0 +1,28 @@
+import { compareDateStamp, nextDay } from "./types";
+import type { DateStamp, Job } from "./types";
+
+export class Scheduler {
+  private queue: Job[] = [];
+
+  enqueue(when: DateStamp, job: () => void): void {
+    this.queue.push({ when: { ...when }, run: job });
+    this.queue.sort((a, b) => compareDateStamp(a.when, b.when));
+  }
+
+  runDay(date: DateStamp): void {
+    while (this.queue.length && compareDateStamp(this.queue[0].when, date) <= 0) {
+      const job = this.queue.shift();
+      job?.run();
+    }
+  }
+
+  advance(date: DateStamp, days: number, handler: (current: DateStamp) => void): DateStamp {
+    let cursor = { ...date };
+    for (let i = 0; i < days; i += 1) {
+      handler(cursor);
+      this.runDay(cursor);
+      cursor = nextDay(cursor);
+    }
+    return cursor;
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,50 @@
+export type ID = string;
+
+export interface DateStamp {
+  season: number;
+  week: number;
+  day: number;
+}
+
+export interface RNGSeed {
+  s1: number;
+  s2: number;
+}
+
+export interface Command<T = any> {
+  type: string;
+  payload: T;
+}
+
+export interface Job {
+  when: DateStamp;
+  run: () => void;
+}
+
+export interface Result<T> {
+  ok: boolean;
+  value?: T;
+  error?: string;
+}
+
+export function cloneDateStamp(date: DateStamp): DateStamp {
+  return { ...date };
+}
+
+export function compareDateStamp(a: DateStamp, b: DateStamp): number {
+  if (a.season !== b.season) return a.season - b.season;
+  if (a.week !== b.week) return a.week - b.week;
+  return a.day - b.day;
+}
+
+export function nextDay(date: DateStamp): DateStamp {
+  const day = date.day + 1;
+  if (day < 7) {
+    return { ...date, day };
+  }
+  const week = date.week + 1;
+  if (week < 52) {
+    return { season: date.season, week, day: 0 };
+  }
+  return { season: date.season + 1, week: 0, day: 0 };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -48,3 +48,15 @@ export function nextDay(date: DateStamp): DateStamp {
   }
   return { season: date.season + 1, week: 0, day: 0 };
 }
+
+export function addDays(date: DateStamp, days: number): DateStamp {
+  let result = { ...date };
+  for (let i = 0; i < days; i += 1) {
+    result = nextDay(result);
+  }
+  return result;
+}
+
+export function sameDate(a: DateStamp, b: DateStamp): boolean {
+  return a.season === b.season && a.week === b.week && a.day === b.day;
+}

--- a/src/data/leagues.ts
+++ b/src/data/leagues.ts
@@ -1,0 +1,509 @@
+import type { Foot, Position } from "@domain/player/types";
+import type { ClubTemplate, LeagueData, PlayerTemplate } from "./premierLeague";
+import { premierLeagueData } from "./premierLeague";
+
+type Strength = "elite" | "contender" | "challenger" | "solid" | "rising" | "developing";
+
+interface SyntheticLeagueConfig {
+  id: string;
+  name: string;
+  nation: string;
+  level: number;
+  nationCode: string;
+  clubs: SyntheticClubConfig[];
+}
+
+interface SyntheticClubConfig {
+  id: string;
+  name: string;
+  shortName: string;
+  colors: string[];
+  strength: Strength;
+  formation?: string;
+  mentality?: ClubTemplate["mentality"];
+  tempo?: number;
+  press?: number;
+  transferBudget?: number;
+  wageBudget?: number;
+  rep?: number;
+  nationality?: string;
+  qualityDelta?: number;
+}
+
+interface NamePool {
+  first: string[];
+  last: string[];
+}
+
+const strengthPresets: Record<Strength, { baseAbility: number; rep: number; transferBudget: number; wageBudget: number; tempo: number; press: number }> = {
+  elite: { baseAbility: 162, rep: 9050, transferBudget: 120_000_000, wageBudget: 2_600_000, tempo: 66, press: 68 },
+  contender: { baseAbility: 152, rep: 8600, transferBudget: 80_000_000, wageBudget: 1_900_000, tempo: 64, press: 66 },
+  challenger: { baseAbility: 144, rep: 8100, transferBudget: 55_000_000, wageBudget: 1_300_000, tempo: 62, press: 64 },
+  solid: { baseAbility: 136, rep: 7600, transferBudget: 34_000_000, wageBudget: 950_000, tempo: 60, press: 62 },
+  rising: { baseAbility: 128, rep: 7000, transferBudget: 22_000_000, wageBudget: 700_000, tempo: 58, press: 60 },
+  developing: { baseAbility: 120, rep: 6400, transferBudget: 12_000_000, wageBudget: 480_000, tempo: 56, press: 58 }
+};
+
+const abilityOffsets = [8, 4, -4, 0, 6, -2, -6, 3, 5, -5, 7, -3, 2, -1, 4, -4, 6, -6, 1, -2];
+
+const squadBlueprint: { positions: Position[]; preferredFoot?: Foot }[] = [
+  { positions: ["GK"], preferredFoot: "Right" },
+  { positions: ["RB"], preferredFoot: "Right" },
+  { positions: ["CB"], preferredFoot: "Right" },
+  { positions: ["CB"], preferredFoot: "Left" },
+  { positions: ["LB"], preferredFoot: "Left" },
+  { positions: ["DM"], preferredFoot: "Right" },
+  { positions: ["CM"], preferredFoot: "Right" },
+  { positions: ["CM"], preferredFoot: "Left" },
+  { positions: ["AM"], preferredFoot: "Right" },
+  { positions: ["RW"], preferredFoot: "Left" },
+  { positions: ["LW"], preferredFoot: "Right" },
+  { positions: ["ST"], preferredFoot: "Right" },
+  { positions: ["GK"], preferredFoot: "Left" },
+  { positions: ["CB"], preferredFoot: "Right" },
+  { positions: ["RB", "LB"], preferredFoot: "Both" },
+  { positions: ["DM", "CM"], preferredFoot: "Right" },
+  { positions: ["CM"], preferredFoot: "Left" },
+  { positions: ["AM", "RW"], preferredFoot: "Left" },
+  { positions: ["ST"], preferredFoot: "Left" },
+  { positions: ["LW", "ST"], preferredFoot: "Right" }
+];
+
+const namesByNation: Record<string, NamePool> = {
+  ENG: { first: ["James", "Harry", "Declan", "Marcus", "Bukayo", "Phil"], last: ["Walker", "Smith", "Johnson", "Brown", "Wilson", "Taylor"] },
+  ESP: { first: ["Pedro", "Sergio", "Iker", "Marco", "Unai", "Andrés"], last: ["García", "Hernández", "Alonso", "Martínez", "Ruiz", "Santos"] },
+  ITA: { first: ["Marco", "Federico", "Lorenzo", "Nicolo", "Sandro", "Gianluca"], last: ["Rossi", "Bianchi", "Esposito", "Ferrari", "Mancini", "Romano"] },
+  GER: { first: ["Jonas", "Lukas", "Leon", "Julian", "Timo", "Florian"], last: ["Müller", "Schmidt", "Schneider", "Fischer", "Becker", "Wagner"] },
+  FRA: { first: ["Kylian", "Antoine", "Benjamin", "Theo", "Loïc", "Adrien"], last: ["Dupont", "Bernard", "Moreau", "Lefevre", "Roux", "Fontaine"] },
+  NED: { first: ["Davy", "Memphis", "Stefan", "Jurrien", "Cody", "Xavi"], last: ["de Jong", "van Dijk", "Klaassen", "Bergkamp", "Koopmeiners", "Blind"] },
+  PRT: { first: ["Rui", "João", "Gonçalo", "Pedro", "Nuno", "Tiago"], last: ["Silva", "Costa", "Pereira", "Ferreira", "Carvalho", "Santos"] },
+  USA: { first: ["Tyler", "Christian", "Weston", "Brenden", "Giovanni", "Miles"], last: ["Adams", "Pulisic", "McKennie", "Aaronson", "Dest", "Zimmerman"] },
+  BRA: { first: ["Gabriel", "Lucas", "Raphinha", "Danilo", "João", "Pedro"], last: ["Silva", "Souza", "Oliveira", "Costa", "Ferreira", "Alves"] },
+  JPN: { first: ["Daichi", "Takumi", "Ritsu", "Wataru", "Takehiro", "Kaoru"], last: ["Tanaka", "Minamino", "Doan", "Endo", "Tomiyasu", "Mitoma"] }
+};
+
+const defaultNames: NamePool = {
+  first: ["Alex", "Sam", "Jordan", "Taylor", "Morgan", "Casey"],
+  last: ["Andersen", "Lopez", "Ivanov", "Petrov", "Khan", "Singh"]
+};
+
+function createSyntheticLeague(config: SyntheticLeagueConfig): LeagueData {
+  return {
+    id: config.id,
+    name: config.name,
+    nation: config.nation,
+    level: config.level,
+    clubs: config.clubs.map((club) => createSyntheticClub(club, config))
+  };
+}
+
+function createSyntheticClub(club: SyntheticClubConfig, league: SyntheticLeagueConfig): ClubTemplate {
+  const preset = strengthPresets[club.strength];
+  const qualityDelta = club.qualityDelta ?? 0;
+  const nationality = club.nationality ?? league.nationCode;
+  const baseAbility = preset.baseAbility + qualityDelta;
+
+  return {
+    id: club.id,
+    name: club.name,
+    shortName: club.shortName,
+    colors: club.colors,
+    formation: club.formation ?? "4-3-3",
+    mentality: club.mentality ?? "Balanced",
+    tempo: club.tempo ?? preset.tempo,
+    press: club.press ?? preset.press,
+    rep: club.rep ?? preset.rep,
+    transferBudget: club.transferBudget ?? preset.transferBudget,
+    wageBudget: club.wageBudget ?? preset.wageBudget,
+    players: createSyntheticSquad(club.id, nationality, baseAbility)
+  };
+}
+
+function createSyntheticSquad(clubId: string, nationality: string, baseAbility: number): PlayerTemplate[] {
+  const pool = namesByNation[nationality] ?? defaultNames;
+  const seed = hashString(clubId);
+  return squadBlueprint.map((slot, index) => {
+    const first = pool.first[(index + seed) % pool.first.length];
+    const last = pool.last[(index * 2 + seed) % pool.last.length];
+    const ca = clamp(baseAbility + abilityOffsets[index % abilityOffsets.length], 94, 178);
+    const pa = clamp(ca + 8 + ((index + seed) % 4) * 3, ca + 5, 190);
+    const value = Math.round(Math.max(500_000, (ca ** 2) * 750));
+    const wage = Math.round(Math.max(6_000, ca * 800));
+    const foot: Foot = slot.preferredFoot ?? (index % 3 === 0 ? "Right" : index % 3 === 1 ? "Left" : "Both");
+
+    return {
+      id: `${clubId}-p${index + 1}`,
+      name: `${first} ${last}`,
+      age: 19 + ((index + seed) % 12),
+      nationality,
+      foot,
+      positions: slot.positions,
+      currentAbility: ca,
+      potentialAbility: pa,
+      value,
+      wage,
+      contractYears: 3 + ((index + seed) % 3)
+    };
+  });
+}
+
+function hashString(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 31 + input.charCodeAt(i)) % 97;
+  }
+  return hash;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+const syntheticLeagues: LeagueData[] = [
+  createSyntheticLeague({
+    id: "la-liga",
+    name: "La Liga",
+    nation: "Spain",
+    level: 1,
+    nationCode: "ESP",
+    clubs: [
+      { id: "real-madrid", name: "Real Madrid", shortName: "RMA", colors: ["#ffffff", "#3a296d"], strength: "elite", mentality: "Positive", qualityDelta: 6 },
+      { id: "barcelona", name: "FC Barcelona", shortName: "BAR", colors: ["#004d98", "#a50044"], strength: "elite", mentality: "Positive", tempo: 68, press: 70 },
+      { id: "atletico-madrid", name: "Atlético Madrid", shortName: "ATL", colors: ["#c8102e", "#041e42"], strength: "contender", mentality: "Cautious" },
+      { id: "real-sociedad", name: "Real Sociedad", shortName: "RSO", colors: ["#005aa7", "#ffffff"], strength: "challenger" },
+      { id: "villarreal", name: "Villarreal", shortName: "VIL", colors: ["#fbe106", "#0b1f8c"], strength: "challenger", mentality: "Positive" },
+      { id: "sevilla", name: "Sevilla", shortName: "SEV", colors: ["#ffffff", "#ff0000"], strength: "challenger" },
+      { id: "real-betis", name: "Real Betis", shortName: "BET", colors: ["#00965e", "#ffffff"], strength: "solid" },
+      { id: "athletic-club", name: "Athletic Club", shortName: "ATH", colors: ["#da1212", "#ffffff"], strength: "solid" },
+      { id: "valencia", name: "Valencia CF", shortName: "VAL", colors: ["#ff8200", "#000000"], strength: "solid" },
+      { id: "girona", name: "Girona FC", shortName: "GIR", colors: ["#e5002b", "#ffffff"], strength: "rising" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "serie-a",
+    name: "Serie A",
+    nation: "Italy",
+    level: 1,
+    nationCode: "ITA",
+    clubs: [
+      { id: "inter", name: "Inter", shortName: "INT", colors: ["#1b65be", "#000000"], strength: "elite", mentality: "Positive", press: 69 },
+      { id: "juventus", name: "Juventus", shortName: "JUV", colors: ["#000000", "#ffffff"], strength: "elite", mentality: "Balanced" },
+      { id: "ac-milan", name: "AC Milan", shortName: "MIL", colors: ["#a50044", "#000000"], strength: "contender", mentality: "Positive" },
+      { id: "napoli", name: "Napoli", shortName: "NAP", colors: ["#0078d7", "#002654"], strength: "contender" },
+      { id: "roma", name: "AS Roma", shortName: "ROM", colors: ["#8e1f1f", "#f7a81b"], strength: "challenger" },
+      { id: "lazio", name: "Lazio", shortName: "LAZ", colors: ["#65aadb", "#ffffff"], strength: "challenger" },
+      { id: "atalanta", name: "Atalanta", shortName: "ATA", colors: ["#1f4e8c", "#000000"], strength: "challenger" },
+      { id: "fiorentina", name: "Fiorentina", shortName: "FIO", colors: ["#592d82", "#ffffff"], strength: "solid" },
+      { id: "bologna", name: "Bologna", shortName: "BOL", colors: ["#a6192e", "#132257"], strength: "solid" },
+      { id: "torino", name: "Torino", shortName: "TOR", colors: ["#7f1d1d", "#ffffff"], strength: "solid" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "bundesliga",
+    name: "Bundesliga",
+    nation: "Germany",
+    level: 1,
+    nationCode: "GER",
+    clubs: [
+      { id: "bayern", name: "Bayern Munich", shortName: "FCB", colors: ["#dc052d", "#0066b2"], strength: "elite", mentality: "Positive", tempo: 70 },
+      { id: "dortmund", name: "Borussia Dortmund", shortName: "BVB", colors: ["#fdd102", "#000000"], strength: "contender", mentality: "Positive" },
+      { id: "rb-leipzig", name: "RB Leipzig", shortName: "RBL", colors: ["#d72027", "#ffffff"], strength: "contender" },
+      { id: "leverkusen", name: "Bayer Leverkusen", shortName: "B04", colors: ["#e32219", "#000000"], strength: "challenger" },
+      { id: "union-berlin", name: "Union Berlin", shortName: "FCU", colors: ["#e31b23", "#f4c300"], strength: "challenger", mentality: "Cautious" },
+      { id: "freiburg", name: "SC Freiburg", shortName: "SCF", colors: ["#000000", "#ffffff"], strength: "solid" },
+      { id: "stuttgart", name: "VfB Stuttgart", shortName: "VFB", colors: ["#ed2939", "#ffffff"], strength: "solid" },
+      { id: "frankfurt", name: "Eintracht Frankfurt", shortName: "SGE", colors: ["#e60026", "#000000"], strength: "solid" },
+      { id: "monchengladbach", name: "Borussia M'Gladbach", shortName: "BMG", colors: ["#0b5c0b", "#ffffff"], strength: "solid" },
+      { id: "wolfsburg", name: "Wolfsburg", shortName: "WOB", colors: ["#14b53a", "#ffffff"], strength: "solid" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "ligue-1",
+    name: "Ligue 1",
+    nation: "France",
+    level: 1,
+    nationCode: "FRA",
+    clubs: [
+      { id: "psg", name: "Paris Saint-Germain", shortName: "PSG", colors: ["#004170", "#e30613"], strength: "elite", mentality: "Positive", press: 72 },
+      { id: "marseille", name: "Marseille", shortName: "OM", colors: ["#00a3e0", "#ffffff"], strength: "contender", mentality: "Positive" },
+      { id: "monaco", name: "AS Monaco", shortName: "ASM", colors: ["#e2001a", "#ffffff"], strength: "contender" },
+      { id: "lyon", name: "Lyon", shortName: "OL", colors: ["#273e8c", "#e60012"], strength: "challenger" },
+      { id: "lille", name: "Lille", shortName: "LIL", colors: ["#e2001a", "#1b3f8b"], strength: "challenger" },
+      { id: "rennes", name: "Rennes", shortName: "REN", colors: ["#e41b17", "#1d1d1b"], strength: "challenger" },
+      { id: "nice", name: "Nice", shortName: "NCE", colors: ["#a00000", "#000000"], strength: "solid" },
+      { id: "lens", name: "Lens", shortName: "RCL", colors: ["#f4d130", "#c30404"], strength: "solid" },
+      { id: "nantes", name: "Nantes", shortName: "NAN", colors: ["#ffe600", "#007a33"], strength: "rising" },
+      { id: "reims", name: "Reims", shortName: "REI", colors: ["#d40000", "#ffffff"], strength: "rising" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "eredivisie",
+    name: "Eredivisie",
+    nation: "Netherlands",
+    level: 1,
+    nationCode: "NED",
+    clubs: [
+      { id: "ajax", name: "Ajax", shortName: "AJA", colors: ["#ffffff", "#d20a0a"], strength: "contender", mentality: "Positive" },
+      { id: "psv", name: "PSV", shortName: "PSV", colors: ["#ff0000", "#ffffff"], strength: "contender" },
+      { id: "feyenoord", name: "Feyenoord", shortName: "FEY", colors: ["#ff0000", "#ffffff"], strength: "contender" },
+      { id: "az-alkmaar", name: "AZ Alkmaar", shortName: "AZ", colors: ["#e2001a", "#000000"], strength: "challenger" },
+      { id: "twente", name: "FC Twente", shortName: "TWE", colors: ["#d71920", "#ffffff"], strength: "challenger" },
+      { id: "utrecht", name: "FC Utrecht", shortName: "UTR", colors: ["#d71920", "#005ca7"], strength: "solid" },
+      { id: "heerenveen", name: "Heerenveen", shortName: "HEE", colors: ["#0b4ea2", "#ffffff"], strength: "solid" },
+      { id: "vitesse", name: "Vitesse", shortName: "VIT", colors: ["#f6c800", "#000000"], strength: "solid" },
+      { id: "groningen", name: "Groningen", shortName: "GRO", colors: ["#009639", "#ffffff"], strength: "rising" },
+      { id: "nec", name: "NEC Nijmegen", shortName: "NEC", colors: ["#009639", "#e03c31"], strength: "rising" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "primeira-liga",
+    name: "Primeira Liga",
+    nation: "Portugal",
+    level: 1,
+    nationCode: "PRT",
+    clubs: [
+      { id: "benfica", name: "Benfica", shortName: "BEN", colors: ["#ff0000", "#ffffff"], strength: "contender", mentality: "Positive" },
+      { id: "porto", name: "FC Porto", shortName: "FCP", colors: ["#0033a0", "#ffffff"], strength: "contender" },
+      { id: "sporting", name: "Sporting CP", shortName: "SCP", colors: ["#00874b", "#ffffff"], strength: "contender" },
+      { id: "braga", name: "SC Braga", shortName: "BRA", colors: ["#c4171d", "#ffffff"], strength: "challenger" },
+      { id: "guimaraes", name: "Vitória SC", shortName: "GUI", colors: ["#ffffff", "#000000"], strength: "challenger" },
+      { id: "boavista", name: "Boavista", shortName: "BOA", colors: ["#000000", "#ffffff"], strength: "solid" },
+      { id: "rio-ave", name: "Rio Ave", shortName: "RIO", colors: ["#009639", "#ff8200"], strength: "solid" },
+      { id: "famalicao", name: "Famalicão", shortName: "FAM", colors: ["#003a70", "#fdda24"], strength: "solid" },
+      { id: "estoril", name: "Estoril", shortName: "EST", colors: ["#fdda24", "#0033a0"], strength: "rising" },
+      { id: "gil-vicente", name: "Gil Vicente", shortName: "GIL", colors: ["#e00034", "#001489"], strength: "rising" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "mls",
+    name: "Major League Soccer",
+    nation: "United States",
+    level: 1,
+    nationCode: "USA",
+    clubs: [
+      { id: "la-galaxy", name: "LA Galaxy", shortName: "LAG", colors: ["#00245d", "#ffd200"], strength: "solid", mentality: "Positive" },
+      { id: "la-fc", name: "LAFC", shortName: "LAFC", colors: ["#000000", "#c59d5f"], strength: "solid" },
+      { id: "seattle", name: "Seattle Sounders", shortName: "SEA", colors: ["#2c68b1", "#66b32e"], strength: "solid" },
+      { id: "atlanta", name: "Atlanta United", shortName: "ATL", colors: ["#a4000f", "#000000"], strength: "solid" },
+      { id: "nycfc", name: "NYCFC", shortName: "NYC", colors: ["#6cadde", "#00285e"], strength: "solid" },
+      { id: "inter-miami", name: "Inter Miami", shortName: "MIA", colors: ["#ff82ad", "#000000"], strength: "rising" },
+      { id: "philadelphia", name: "Philadelphia Union", shortName: "PHI", colors: ["#002d55", "#b4975a"], strength: "solid" },
+      { id: "toronto", name: "Toronto FC", shortName: "TOR", colors: ["#e31837", "#4b9cd3"], strength: "solid" },
+      { id: "new-england", name: "New England Revolution", shortName: "NER", colors: ["#0a2240", "#c8102e"], strength: "rising" },
+      { id: "columbus", name: "Columbus Crew", shortName: "CLB", colors: ["#fedd00", "#000000"], strength: "rising" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "brasileirao",
+    name: "Brasileirão Série A",
+    nation: "Brazil",
+    level: 1,
+    nationCode: "BRA",
+    clubs: [
+      { id: "flamengo", name: "Flamengo", shortName: "FLA", colors: ["#c8102e", "#000000"], strength: "contender", mentality: "Positive" },
+      { id: "palmeiras", name: "Palmeiras", shortName: "PAL", colors: ["#006437", "#ffffff"], strength: "contender" },
+      { id: "corinthians", name: "Corinthians", shortName: "COR", colors: ["#000000", "#ffffff"], strength: "challenger" },
+      { id: "sao-paulo", name: "São Paulo", shortName: "SAO", colors: ["#ff0000", "#000000"], strength: "challenger" },
+      { id: "gremio", name: "Grêmio", shortName: "GRE", colors: ["#0094d4", "#000000"], strength: "challenger" },
+      { id: "internacional", name: "Internacional", shortName: "INT", colors: ["#ff0000", "#ffffff"], strength: "challenger" },
+      { id: "atletico-mg", name: "Atlético Mineiro", shortName: "CAM", colors: ["#000000", "#ffffff"], strength: "challenger" },
+      { id: "fluminense", name: "Fluminense", shortName: "FLU", colors: ["#900021", "#006341"], strength: "solid" },
+      { id: "botafogo", name: "Botafogo", shortName: "BOT", colors: ["#000000", "#ffffff"], strength: "solid" },
+      { id: "santos", name: "Santos", shortName: "SAN", colors: ["#000000", "#ffffff"], strength: "solid" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "j1-league",
+    name: "J1 League",
+    nation: "Japan",
+    level: 1,
+    nationCode: "JPN",
+    clubs: [
+      { id: "kawasaki-frontale", name: "Kawasaki Frontale", shortName: "KAW", colors: ["#00a0e9", "#000000"], strength: "challenger", mentality: "Positive" },
+      { id: "yokohama-f-marinos", name: "Yokohama F. Marinos", shortName: "YFM", colors: ["#00205b", "#d22f27"], strength: "challenger" },
+      { id: "kashima-antlers", name: "Kashima Antlers", shortName: "KAS", colors: ["#c8102e", "#00205b"], strength: "challenger" },
+      { id: "urawa-reds", name: "Urawa Reds", shortName: "URW", colors: ["#c8102e", "#000000"], strength: "challenger" },
+      { id: "cerezo-osaka", name: "Cerezo Osaka", shortName: "CER", colors: ["#ff5fa2", "#002a5c"], strength: "solid" },
+      { id: "gamba-osaka", name: "Gamba Osaka", shortName: "GAM", colors: ["#0c1b3a", "#0091d4"], strength: "solid" },
+      { id: "hiroshima", name: "Sanfrecce Hiroshima", shortName: "SAN", colors: ["#4c2f91", "#ffffff"], strength: "solid" },
+      { id: "vissel-kobe", name: "Vissel Kobe", shortName: "VIS", colors: ["#9c1830", "#ffffff"], strength: "solid" },
+      { id: "fc-tokyo", name: "FC Tokyo", shortName: "FCT", colors: ["#003da5", "#d50032"], strength: "solid" },
+      { id: "nagoya", name: "Nagoya Grampus", shortName: "NAG", colors: ["#e60012", "#f8b500"], strength: "solid" }
+    ]
+  }),
+  // Second tiers for the top six leagues
+  createSyntheticLeague({
+    id: "championship",
+    name: "EFL Championship",
+    nation: "England",
+    level: 2,
+    nationCode: "ENG",
+    clubs: [
+      { id: "leicester", name: "Leicester City", shortName: "LEI", colors: ["#003090", "#fdb913"], strength: "challenger" },
+      { id: "leeds", name: "Leeds United", shortName: "LEE", colors: ["#fff200", "#1d428a"], strength: "challenger" },
+      { id: "southampton", name: "Southampton", shortName: "SOU", colors: ["#d71920", "#130c0e"], strength: "challenger" },
+      { id: "ipswich", name: "Ipswich Town", shortName: "IPS", colors: ["#003399", "#ffffff"], strength: "solid" },
+      { id: "watford", name: "Watford", shortName: "WAT", colors: ["#fbee23", "#ed2127"], strength: "solid" },
+      { id: "norwich", name: "Norwich", shortName: "NOR", colors: ["#fff200", "#007f3a"], strength: "solid" },
+      { id: "sunderland", name: "Sunderland", shortName: "SUN", colors: ["#ee2737", "#ffffff"], strength: "solid" },
+      { id: "middlesbrough", name: "Middlesbrough", shortName: "MID", colors: ["#da2128", "#ffffff"], strength: "solid" },
+      { id: "coventry", name: "Coventry City", shortName: "COV", colors: ["#8dc1e8", "#000000"], strength: "rising" },
+      { id: "west-brom", name: "West Brom", shortName: "WBA", colors: ["#0d2340", "#ffffff"], strength: "rising" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "la-liga-2",
+    name: "La Liga 2",
+    nation: "Spain",
+    level: 2,
+    nationCode: "ESP",
+    clubs: [
+      { id: "leganes", name: "Leganés", shortName: "LEG", colors: ["#ffffff", "#005baa"], strength: "solid" },
+      { id: "espanyol", name: "Espanyol", shortName: "ESP", colors: ["#007ac2", "#ffffff"], strength: "solid" },
+      { id: "elche", name: "Elche", shortName: "ELC", colors: ["#0f7b3e", "#ffffff"], strength: "solid" },
+      { id: "oviedo", name: "Real Oviedo", shortName: "OVI", colors: ["#0055a4", "#ffc400"], strength: "solid" },
+      { id: "zaragoza", name: "Real Zaragoza", shortName: "ZAR", colors: ["#00529f", "#ffffff"], strength: "solid" },
+      { id: "levante", name: "Levante", shortName: "LEV", colors: ["#041c2c", "#9e1b32"], strength: "solid" },
+      { id: "malaga", name: "Málaga", shortName: "MAL", colors: ["#6bb3dd", "#ffffff"], strength: "rising" },
+      { id: "tenerife", name: "Tenerife", shortName: "TEN", colors: ["#1c3f95", "#ffffff"], strength: "rising" },
+      { id: "valladolid", name: "Valladolid", shortName: "VLL", colors: ["#4b0082", "#ffffff"], strength: "rising" },
+      { id: "sporting-gijon", name: "Sporting Gijón", shortName: "SPG", colors: ["#d50032", "#ffffff"], strength: "rising" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "serie-b",
+    name: "Serie B",
+    nation: "Italy",
+    level: 2,
+    nationCode: "ITA",
+    clubs: [
+      { id: "parma", name: "Parma", shortName: "PAR", colors: ["#002f87", "#ffdd00"], strength: "solid" },
+      { id: "palermo", name: "Palermo", shortName: "PAL", colors: ["#f5a8b8", "#000000"], strength: "solid" },
+      { id: "cagliari", name: "Cagliari", shortName: "CAG", colors: ["#003366", "#a50034"], strength: "solid" },
+      { id: "brescia", name: "Brescia", shortName: "BRE", colors: ["#0054a6", "#ffffff"], strength: "solid" },
+      { id: "como", name: "Como", shortName: "COM", colors: ["#003399", "#ffffff"], strength: "solid" },
+      { id: "pisa", name: "Pisa", shortName: "PIS", colors: ["#000000", "#0076bf"], strength: "rising" },
+      { id: "frosinone", name: "Frosinone", shortName: "FRO", colors: ["#004aad", "#ffda44"], strength: "rising" },
+      { id: "spezia", name: "Spezia", shortName: "SPE", colors: ["#000000", "#ffffff"], strength: "rising" },
+      { id: "reggina", name: "Reggina", shortName: "REG", colors: ["#800000", "#ffffff"], strength: "rising" },
+      { id: "lecce", name: "Lecce", shortName: "LEC", colors: ["#004aad", "#ffdd00"], strength: "rising" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "2-bundesliga",
+    name: "2. Bundesliga",
+    nation: "Germany",
+    level: 2,
+    nationCode: "GER",
+    clubs: [
+      { id: "hamburg", name: "Hamburg", shortName: "HSV", colors: ["#005ca9", "#ffffff"], strength: "solid" },
+      { id: "schalke", name: "Schalke", shortName: "S04", colors: ["#0d47a1", "#ffffff"], strength: "solid" },
+      { id: "hertha", name: "Hertha BSC", shortName: "BSC", colors: ["#0041ab", "#ffffff"], strength: "solid" },
+      { id: "st-pauli", name: "St. Pauli", shortName: "STP", colors: ["#4b3621", "#ffffff"], strength: "solid" },
+      { id: "dusseldorf", name: "Fortuna Düsseldorf", shortName: "F95", colors: ["#d11241", "#ffffff"], strength: "solid" },
+      { id: "hannover", name: "Hannover 96", shortName: "H96", colors: ["#006633", "#000000"], strength: "solid" },
+      { id: "nurnberg", name: "Nürnberg", shortName: "FCN", colors: ["#800000", "#ffffff"], strength: "solid" },
+      { id: "paderborn", name: "Paderborn", shortName: "SCP", colors: ["#003399", "#ffffff"], strength: "rising" },
+      { id: "karlsruhe", name: "Karlsruhe", shortName: "KSC", colors: ["#0054a6", "#ffffff"], strength: "rising" },
+      { id: "holstein-kiel", name: "Holstein Kiel", shortName: "KIE", colors: ["#005ca9", "#ff0000"], strength: "rising" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "ligue-2",
+    name: "Ligue 2",
+    nation: "France",
+    level: 2,
+    nationCode: "FRA",
+    clubs: [
+      { id: "auxerre", name: "Auxerre", shortName: "AJA", colors: ["#0f5bb3", "#ffffff"], strength: "solid" },
+      { id: "saint-etienne", name: "Saint-Étienne", shortName: "ASSE", colors: ["#00a55c", "#ffffff"], strength: "solid" },
+      { id: "angers", name: "Angers SCO", shortName: "ANG", colors: ["#000000", "#ffffff"], strength: "solid" },
+      { id: "caen", name: "Caen", shortName: "CAE", colors: ["#003087", "#e4002b"], strength: "solid" },
+      { id: "guingamp", name: "Guingamp", shortName: "GUI", colors: ["#d40000", "#000000"], strength: "solid" },
+      { id: "bastia", name: "Bastia", shortName: "BAS", colors: ["#0033a0", "#ffffff"], strength: "solid" },
+      { id: "dijon", name: "Dijon", shortName: "DIJ", colors: ["#d50032", "#ffffff"], strength: "rising" },
+      { id: "sochaux", name: "Sochaux", shortName: "SOC", colors: ["#f9d616", "#003a70"], strength: "rising" },
+      { id: "grenoble", name: "Grenoble", shortName: "GRE", colors: ["#00539f", "#ffffff"], strength: "rising" },
+      { id: "amiens", name: "Amiens", shortName: "AMI", colors: ["#6c757d", "#ffffff"], strength: "rising" }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "eerste-divisie",
+    name: "Eerste Divisie",
+    nation: "Netherlands",
+    level: 2,
+    nationCode: "NED",
+    clubs: [
+      { id: "zwolle", name: "PEC Zwolle", shortName: "ZWO", colors: ["#007bc7", "#ffffff"], strength: "solid" },
+      { id: "willem-ii", name: "Willem II", shortName: "WII", colors: ["#a50034", "#132257"], strength: "solid" },
+      { id: "nac-breda", name: "NAC Breda", shortName: "NAC", colors: ["#ffcc00", "#000000"], strength: "solid" },
+      { id: "de-graafschap", name: "De Graafschap", shortName: "GRA", colors: ["#0b4ea2", "#ffffff"], strength: "solid" },
+      { id: "roda-jc", name: "Roda JC", shortName: "RJC", colors: ["#ffcd00", "#000000"], strength: "solid" },
+      { id: "den-haag", name: "ADO Den Haag", shortName: "ADO", colors: ["#007f3b", "#ffdd00"], strength: "rising" },
+      { id: "almere-city", name: "Almere City", shortName: "ALM", colors: ["#e32219", "#ffffff"], strength: "rising" },
+      { id: "excelsior", name: "Excelsior", shortName: "EXC", colors: ["#000000", "#ffffff"], strength: "rising" },
+      { id: "top-oss", name: "TOP Oss", shortName: "OSS", colors: ["#d50032", "#ffffff"], strength: "developing" },
+      { id: "telstar", name: "Telstar", shortName: "TEL", colors: ["#ffffff", "#f9a602"], strength: "developing" }
+    ]
+  }),
+  // Third tiers for the top three countries
+  createSyntheticLeague({
+    id: "league-one",
+    name: "EFL League One",
+    nation: "England",
+    level: 3,
+    nationCode: "ENG",
+    clubs: [
+      { id: "portsmouth", name: "Portsmouth", shortName: "POR", colors: ["#003399", "#ffffff"], strength: "rising", transferBudget: 12_000_000, wageBudget: 400_000 },
+      { id: "derby", name: "Derby County", shortName: "DER", colors: ["#000000", "#ffffff"], strength: "rising", transferBudget: 11_000_000, wageBudget: 380_000 },
+      { id: "bolton", name: "Bolton Wanderers", shortName: "BOL", colors: ["#001489", "#ffffff"], strength: "rising", transferBudget: 10_000_000, wageBudget: 360_000 },
+      { id: "blackpool", name: "Blackpool", shortName: "BLA", colors: ["#ff5f00", "#ffffff"], strength: "developing", transferBudget: 9_000_000, wageBudget: 340_000 },
+      { id: "charlton", name: "Charlton", shortName: "CHA", colors: ["#c60c30", "#ffffff"], strength: "developing", transferBudget: 8_000_000, wageBudget: 320_000 },
+      { id: "wycombe", name: "Wycombe", shortName: "WYC", colors: ["#4f9ec4", "#0f1c2c"], strength: "developing", transferBudget: 7_500_000, wageBudget: 300_000 },
+      { id: "peterborough", name: "Peterborough", shortName: "PET", colors: ["#0057b7", "#ffffff"], strength: "developing", transferBudget: 7_000_000, wageBudget: 280_000 },
+      { id: "oxford", name: "Oxford United", shortName: "OXF", colors: ["#f4c800", "#001489"], strength: "developing", transferBudget: 6_500_000, wageBudget: 260_000 },
+      { id: "barnsley", name: "Barnsley", shortName: "BAR", colors: ["#c8102e", "#ffffff"], strength: "developing", transferBudget: 6_000_000, wageBudget: 250_000 },
+      { id: "lincoln", name: "Lincoln City", shortName: "LIN", colors: ["#d4021d", "#ffffff"], strength: "developing", transferBudget: 5_500_000, wageBudget: 230_000 }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "primera-rfef",
+    name: "Primera Federación",
+    nation: "Spain",
+    level: 3,
+    nationCode: "ESP",
+    clubs: [
+      { id: "deportivo", name: "Deportivo La Coruña", shortName: "DEP", colors: ["#1d4ba0", "#ffffff"], strength: "rising", transferBudget: 8_500_000, wageBudget: 320_000 },
+      { id: "cordoba", name: "Córdoba", shortName: "COR", colors: ["#007a33", "#ffffff"], strength: "rising", transferBudget: 7_800_000, wageBudget: 300_000 },
+      { id: "cultural", name: "Cultural Leonesa", shortName: "CUL", colors: ["#ffffff", "#c8102e"], strength: "developing", transferBudget: 7_200_000, wageBudget: 280_000 },
+      { id: "murcia", name: "Real Murcia", shortName: "MUR", colors: ["#c8102e", "#ffffff"], strength: "developing", transferBudget: 6_800_000, wageBudget: 260_000 },
+      { id: "ponferradina", name: "Ponferradina", shortName: "PON", colors: ["#003399", "#ffffff"], strength: "developing", transferBudget: 6_500_000, wageBudget: 250_000 },
+      { id: "alcorcon", name: "Alcorcón", shortName: "ALC", colors: ["#ffd100", "#0033a0"], strength: "developing", transferBudget: 6_000_000, wageBudget: 230_000 },
+      { id: "sabadell", name: "Sabadell", shortName: "SAB", colors: ["#1b3f8b", "#ffffff"], strength: "developing", transferBudget: 5_800_000, wageBudget: 220_000 },
+      { id: "castellon", name: "Castellón", shortName: "CAS", colors: ["#000000", "#ffffff"], strength: "developing", transferBudget: 5_500_000, wageBudget: 210_000 },
+      { id: "ferrol", name: "Racing Ferrol", shortName: "FER", colors: ["#007f3a", "#ffffff"], strength: "developing", transferBudget: 5_200_000, wageBudget: 200_000 },
+      { id: "barcelona-b", name: "Barcelona Atlètic", shortName: "BARB", colors: ["#004d98", "#a50044"], strength: "developing", transferBudget: 5_000_000, wageBudget: 190_000 }
+    ]
+  }),
+  createSyntheticLeague({
+    id: "serie-c",
+    name: "Serie C",
+    nation: "Italy",
+    level: 3,
+    nationCode: "ITA",
+    clubs: [
+      { id: "sudtirol", name: "Südtirol", shortName: "SUD", colors: ["#a50034", "#ffffff"], strength: "rising", transferBudget: 8_000_000, wageBudget: 320_000 },
+      { id: "padova", name: "Padova", shortName: "PAD", colors: ["#c8102e", "#ffffff"], strength: "rising", transferBudget: 7_500_000, wageBudget: 300_000 },
+      { id: "perugia", name: "Perugia", shortName: "PER", colors: ["#d50032", "#ffffff"], strength: "developing", transferBudget: 7_000_000, wageBudget: 280_000 },
+      { id: "ternana", name: "Ternana", shortName: "TER", colors: ["#007a33", "#d50032"], strength: "developing", transferBudget: 6_500_000, wageBudget: 260_000 },
+      { id: "modena", name: "Modena", shortName: "MOD", colors: ["#002d72", "#ffd200"], strength: "developing", transferBudget: 6_200_000, wageBudget: 240_000 },
+      { id: "cesena", name: "Cesena", shortName: "CES", colors: ["#000000", "#ffffff"], strength: "developing", transferBudget: 6_000_000, wageBudget: 230_000 },
+      { id: "catanzaro", name: "Catanzaro", shortName: "CAT", colors: ["#ff0000", "#ffff00"], strength: "developing", transferBudget: 5_800_000, wageBudget: 220_000 },
+      { id: "avellino", name: "Avellino", shortName: "AVE", colors: ["#007a3d", "#ffffff"], strength: "developing", transferBudget: 5_600_000, wageBudget: 210_000 },
+      { id: "monopoli", name: "Monopoli", shortName: "MON", colors: ["#00843d", "#ffffff"], strength: "developing", transferBudget: 5_400_000, wageBudget: 200_000 },
+      { id: "trieste", name: "Triestina", shortName: "TRI", colors: ["#c8102e", "#ffffff"], strength: "developing", transferBudget: 5_200_000, wageBudget: 190_000 }
+    ]
+  })
+];
+
+export const leaguePacks: LeagueData[] = [premierLeagueData, ...syntheticLeagues];

--- a/src/data/leagues.ts
+++ b/src/data/leagues.ts
@@ -26,6 +26,7 @@ interface SyntheticClubConfig {
   transferBudget?: number;
   wageBudget?: number;
   rep?: number;
+  marketValue?: number;
   nationality?: string;
   qualityDelta?: number;
 }
@@ -102,6 +103,13 @@ function createSyntheticClub(club: SyntheticClubConfig, league: SyntheticLeagueC
   const qualityDelta = club.qualityDelta ?? 0;
   const nationality = club.nationality ?? league.nationCode;
   const baseAbility = preset.baseAbility + qualityDelta;
+  const marketValue =
+    club.marketValue ??
+    Math.round(Math.max(28_000_000, (baseAbility - 90) * (baseAbility - 88) * 60_000));
+  const transferBudget = club.transferBudget ?? Math.round(marketValue * 0.085);
+  const wageBudget = club.wageBudget ?? Math.round(Math.max(preset.wageBudget, marketValue * 0.0022));
+  const rep =
+    club.rep ?? Math.round(Math.min(9300, preset.rep + Math.log10(marketValue / 1_000_000) * 460));
 
   return {
     id: club.id,
@@ -112,14 +120,19 @@ function createSyntheticClub(club: SyntheticClubConfig, league: SyntheticLeagueC
     mentality: club.mentality ?? "Balanced",
     tempo: club.tempo ?? preset.tempo,
     press: club.press ?? preset.press,
-    rep: club.rep ?? preset.rep,
-    transferBudget: club.transferBudget ?? preset.transferBudget,
-    wageBudget: club.wageBudget ?? preset.wageBudget,
+    rep,
+    marketValue,
+    transferBudget,
+    wageBudget,
     players: createSyntheticSquad(club.id, nationality, baseAbility)
   };
 }
 
-function createSyntheticSquad(clubId: string, nationality: string, baseAbility: number): PlayerTemplate[] {
+export function createSyntheticSquad(
+  clubId: string,
+  nationality: string,
+  baseAbility: number
+): PlayerTemplate[] {
   const pool = namesByNation[nationality] ?? defaultNames;
   const seed = hashString(clubId);
   return squadBlueprint.map((slot, index) => {
@@ -167,16 +180,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 1,
     nationCode: "ESP",
     clubs: [
-      { id: "real-madrid", name: "Real Madrid", shortName: "RMA", colors: ["#ffffff", "#3a296d"], strength: "elite", mentality: "Positive", qualityDelta: 6 },
-      { id: "barcelona", name: "FC Barcelona", shortName: "BAR", colors: ["#004d98", "#a50044"], strength: "elite", mentality: "Positive", tempo: 68, press: 70 },
-      { id: "atletico-madrid", name: "Atlético Madrid", shortName: "ATL", colors: ["#c8102e", "#041e42"], strength: "contender", mentality: "Cautious" },
-      { id: "real-sociedad", name: "Real Sociedad", shortName: "RSO", colors: ["#005aa7", "#ffffff"], strength: "challenger" },
-      { id: "villarreal", name: "Villarreal", shortName: "VIL", colors: ["#fbe106", "#0b1f8c"], strength: "challenger", mentality: "Positive" },
-      { id: "sevilla", name: "Sevilla", shortName: "SEV", colors: ["#ffffff", "#ff0000"], strength: "challenger" },
-      { id: "real-betis", name: "Real Betis", shortName: "BET", colors: ["#00965e", "#ffffff"], strength: "solid" },
-      { id: "athletic-club", name: "Athletic Club", shortName: "ATH", colors: ["#da1212", "#ffffff"], strength: "solid" },
-      { id: "valencia", name: "Valencia CF", shortName: "VAL", colors: ["#ff8200", "#000000"], strength: "solid" },
-      { id: "girona", name: "Girona FC", shortName: "GIR", colors: ["#e5002b", "#ffffff"], strength: "rising" }
+      { id: "real-madrid", name: "Real Madrid", shortName: "RMA", colors: ["#ffffff", "#3a296d"], strength: "elite", mentality: "Positive", qualityDelta: 6, marketValue: 1_050_000_000 },
+      { id: "barcelona", name: "FC Barcelona", shortName: "BAR", colors: ["#004d98", "#a50044"], strength: "elite", mentality: "Positive", tempo: 68, press: 70, marketValue: 1_020_000_000 },
+      { id: "atletico-madrid", name: "Atlético Madrid", shortName: "ATL", colors: ["#c8102e", "#041e42"], strength: "contender", mentality: "Cautious", marketValue: 620_000_000 },
+      { id: "real-sociedad", name: "Real Sociedad", shortName: "RSO", colors: ["#005aa7", "#ffffff"], strength: "challenger", marketValue: 410_000_000 },
+      { id: "villarreal", name: "Villarreal", shortName: "VIL", colors: ["#fbe106", "#0b1f8c"], strength: "challenger", mentality: "Positive", marketValue: 360_000_000 },
+      { id: "sevilla", name: "Sevilla", shortName: "SEV", colors: ["#ffffff", "#ff0000"], strength: "challenger", marketValue: 280_000_000 },
+      { id: "real-betis", name: "Real Betis", shortName: "BET", colors: ["#00965e", "#ffffff"], strength: "solid", marketValue: 250_000_000 },
+      { id: "athletic-club", name: "Athletic Club", shortName: "ATH", colors: ["#da1212", "#ffffff"], strength: "solid", marketValue: 305_000_000 },
+      { id: "valencia", name: "Valencia CF", shortName: "VAL", colors: ["#ff8200", "#000000"], strength: "solid", marketValue: 220_000_000 },
+      { id: "girona", name: "Girona FC", shortName: "GIR", colors: ["#e5002b", "#ffffff"], strength: "rising", marketValue: 215_000_000 }
     ]
   }),
   createSyntheticLeague({
@@ -186,16 +199,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 1,
     nationCode: "ITA",
     clubs: [
-      { id: "inter", name: "Inter", shortName: "INT", colors: ["#1b65be", "#000000"], strength: "elite", mentality: "Positive", press: 69 },
-      { id: "juventus", name: "Juventus", shortName: "JUV", colors: ["#000000", "#ffffff"], strength: "elite", mentality: "Balanced" },
-      { id: "ac-milan", name: "AC Milan", shortName: "MIL", colors: ["#a50044", "#000000"], strength: "contender", mentality: "Positive" },
-      { id: "napoli", name: "Napoli", shortName: "NAP", colors: ["#0078d7", "#002654"], strength: "contender" },
-      { id: "roma", name: "AS Roma", shortName: "ROM", colors: ["#8e1f1f", "#f7a81b"], strength: "challenger" },
-      { id: "lazio", name: "Lazio", shortName: "LAZ", colors: ["#65aadb", "#ffffff"], strength: "challenger" },
-      { id: "atalanta", name: "Atalanta", shortName: "ATA", colors: ["#1f4e8c", "#000000"], strength: "challenger" },
-      { id: "fiorentina", name: "Fiorentina", shortName: "FIO", colors: ["#592d82", "#ffffff"], strength: "solid" },
-      { id: "bologna", name: "Bologna", shortName: "BOL", colors: ["#a6192e", "#132257"], strength: "solid" },
-      { id: "torino", name: "Torino", shortName: "TOR", colors: ["#7f1d1d", "#ffffff"], strength: "solid" }
+      { id: "inter", name: "Inter", shortName: "INT", colors: ["#1b65be", "#000000"], strength: "elite", mentality: "Positive", press: 69, marketValue: 700_000_000 },
+      { id: "juventus", name: "Juventus", shortName: "JUV", colors: ["#000000", "#ffffff"], strength: "elite", mentality: "Balanced", marketValue: 650_000_000 },
+      { id: "ac-milan", name: "AC Milan", shortName: "MIL", colors: ["#a50044", "#000000"], strength: "contender", mentality: "Positive", marketValue: 560_000_000 },
+      { id: "napoli", name: "Napoli", shortName: "NAP", colors: ["#0078d7", "#002654"], strength: "contender", marketValue: 520_000_000 },
+      { id: "roma", name: "AS Roma", shortName: "ROM", colors: ["#8e1f1f", "#f7a81b"], strength: "challenger", marketValue: 380_000_000 },
+      { id: "lazio", name: "Lazio", shortName: "LAZ", colors: ["#65aadb", "#ffffff"], strength: "challenger", marketValue: 360_000_000 },
+      { id: "atalanta", name: "Atalanta", shortName: "ATA", colors: ["#1f4e8c", "#000000"], strength: "challenger", marketValue: 350_000_000 },
+      { id: "fiorentina", name: "Fiorentina", shortName: "FIO", colors: ["#592d82", "#ffffff"], strength: "solid", marketValue: 290_000_000 },
+      { id: "bologna", name: "Bologna", shortName: "BOL", colors: ["#a6192e", "#132257"], strength: "solid", marketValue: 240_000_000 },
+      { id: "torino", name: "Torino", shortName: "TOR", colors: ["#7f1d1d", "#ffffff"], strength: "solid", marketValue: 210_000_000 }
     ]
   }),
   createSyntheticLeague({
@@ -205,16 +218,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 1,
     nationCode: "GER",
     clubs: [
-      { id: "bayern", name: "Bayern Munich", shortName: "FCB", colors: ["#dc052d", "#0066b2"], strength: "elite", mentality: "Positive", tempo: 70 },
-      { id: "dortmund", name: "Borussia Dortmund", shortName: "BVB", colors: ["#fdd102", "#000000"], strength: "contender", mentality: "Positive" },
-      { id: "rb-leipzig", name: "RB Leipzig", shortName: "RBL", colors: ["#d72027", "#ffffff"], strength: "contender" },
-      { id: "leverkusen", name: "Bayer Leverkusen", shortName: "B04", colors: ["#e32219", "#000000"], strength: "challenger" },
-      { id: "union-berlin", name: "Union Berlin", shortName: "FCU", colors: ["#e31b23", "#f4c300"], strength: "challenger", mentality: "Cautious" },
-      { id: "freiburg", name: "SC Freiburg", shortName: "SCF", colors: ["#000000", "#ffffff"], strength: "solid" },
-      { id: "stuttgart", name: "VfB Stuttgart", shortName: "VFB", colors: ["#ed2939", "#ffffff"], strength: "solid" },
-      { id: "frankfurt", name: "Eintracht Frankfurt", shortName: "SGE", colors: ["#e60026", "#000000"], strength: "solid" },
-      { id: "monchengladbach", name: "Borussia M'Gladbach", shortName: "BMG", colors: ["#0b5c0b", "#ffffff"], strength: "solid" },
-      { id: "wolfsburg", name: "Wolfsburg", shortName: "WOB", colors: ["#14b53a", "#ffffff"], strength: "solid" }
+      { id: "bayern", name: "Bayern Munich", shortName: "FCB", colors: ["#dc052d", "#0066b2"], strength: "elite", mentality: "Positive", tempo: 70, marketValue: 970_000_000 },
+      { id: "dortmund", name: "Borussia Dortmund", shortName: "BVB", colors: ["#fdd102", "#000000"], strength: "contender", mentality: "Positive", marketValue: 650_000_000 },
+      { id: "rb-leipzig", name: "RB Leipzig", shortName: "RBL", colors: ["#d72027", "#ffffff"], strength: "contender", marketValue: 510_000_000 },
+      { id: "leverkusen", name: "Bayer Leverkusen", shortName: "B04", colors: ["#e32219", "#000000"], strength: "challenger", marketValue: 610_000_000 },
+      { id: "union-berlin", name: "Union Berlin", shortName: "FCU", colors: ["#e31b23", "#f4c300"], strength: "challenger", mentality: "Cautious", marketValue: 220_000_000 },
+      { id: "freiburg", name: "SC Freiburg", shortName: "SCF", colors: ["#000000", "#ffffff"], strength: "solid", marketValue: 210_000_000 },
+      { id: "stuttgart", name: "VfB Stuttgart", shortName: "VFB", colors: ["#ed2939", "#ffffff"], strength: "solid", marketValue: 270_000_000 },
+      { id: "frankfurt", name: "Eintracht Frankfurt", shortName: "SGE", colors: ["#e60026", "#000000"], strength: "solid", marketValue: 250_000_000 },
+      { id: "monchengladbach", name: "Borussia M'Gladbach", shortName: "BMG", colors: ["#0b5c0b", "#ffffff"], strength: "solid", marketValue: 220_000_000 },
+      { id: "wolfsburg", name: "Wolfsburg", shortName: "WOB", colors: ["#14b53a", "#ffffff"], strength: "solid", marketValue: 200_000_000 }
     ]
   }),
   createSyntheticLeague({
@@ -224,16 +237,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 1,
     nationCode: "FRA",
     clubs: [
-      { id: "psg", name: "Paris Saint-Germain", shortName: "PSG", colors: ["#004170", "#e30613"], strength: "elite", mentality: "Positive", press: 72 },
-      { id: "marseille", name: "Marseille", shortName: "OM", colors: ["#00a3e0", "#ffffff"], strength: "contender", mentality: "Positive" },
-      { id: "monaco", name: "AS Monaco", shortName: "ASM", colors: ["#e2001a", "#ffffff"], strength: "contender" },
-      { id: "lyon", name: "Lyon", shortName: "OL", colors: ["#273e8c", "#e60012"], strength: "challenger" },
-      { id: "lille", name: "Lille", shortName: "LIL", colors: ["#e2001a", "#1b3f8b"], strength: "challenger" },
-      { id: "rennes", name: "Rennes", shortName: "REN", colors: ["#e41b17", "#1d1d1b"], strength: "challenger" },
-      { id: "nice", name: "Nice", shortName: "NCE", colors: ["#a00000", "#000000"], strength: "solid" },
-      { id: "lens", name: "Lens", shortName: "RCL", colors: ["#f4d130", "#c30404"], strength: "solid" },
-      { id: "nantes", name: "Nantes", shortName: "NAN", colors: ["#ffe600", "#007a33"], strength: "rising" },
-      { id: "reims", name: "Reims", shortName: "REI", colors: ["#d40000", "#ffffff"], strength: "rising" }
+      { id: "psg", name: "Paris Saint-Germain", shortName: "PSG", colors: ["#004170", "#e30613"], strength: "elite", mentality: "Positive", press: 72, marketValue: 890_000_000 },
+      { id: "marseille", name: "Marseille", shortName: "OM", colors: ["#00a3e0", "#ffffff"], strength: "contender", mentality: "Positive", marketValue: 330_000_000 },
+      { id: "monaco", name: "AS Monaco", shortName: "ASM", colors: ["#e2001a", "#ffffff"], strength: "contender", marketValue: 350_000_000 },
+      { id: "lyon", name: "Lyon", shortName: "OL", colors: ["#273e8c", "#e60012"], strength: "challenger", marketValue: 320_000_000 },
+      { id: "lille", name: "Lille", shortName: "LIL", colors: ["#e2001a", "#1b3f8b"], strength: "challenger", marketValue: 320_000_000 },
+      { id: "rennes", name: "Rennes", shortName: "REN", colors: ["#e41b17", "#1d1d1b"], strength: "challenger", marketValue: 310_000_000 },
+      { id: "nice", name: "Nice", shortName: "NCE", colors: ["#a00000", "#000000"], strength: "solid", marketValue: 290_000_000 },
+      { id: "lens", name: "Lens", shortName: "RCL", colors: ["#f4d130", "#c30404"], strength: "solid", marketValue: 280_000_000 },
+      { id: "nantes", name: "Nantes", shortName: "NAN", colors: ["#ffe600", "#007a33"], strength: "rising", marketValue: 145_000_000 },
+      { id: "reims", name: "Reims", shortName: "REI", colors: ["#d40000", "#ffffff"], strength: "rising", marketValue: 170_000_000 }
     ]
   }),
   createSyntheticLeague({
@@ -243,16 +256,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 1,
     nationCode: "NED",
     clubs: [
-      { id: "ajax", name: "Ajax", shortName: "AJA", colors: ["#ffffff", "#d20a0a"], strength: "contender", mentality: "Positive" },
-      { id: "psv", name: "PSV", shortName: "PSV", colors: ["#ff0000", "#ffffff"], strength: "contender" },
-      { id: "feyenoord", name: "Feyenoord", shortName: "FEY", colors: ["#ff0000", "#ffffff"], strength: "contender" },
-      { id: "az-alkmaar", name: "AZ Alkmaar", shortName: "AZ", colors: ["#e2001a", "#000000"], strength: "challenger" },
-      { id: "twente", name: "FC Twente", shortName: "TWE", colors: ["#d71920", "#ffffff"], strength: "challenger" },
-      { id: "utrecht", name: "FC Utrecht", shortName: "UTR", colors: ["#d71920", "#005ca7"], strength: "solid" },
-      { id: "heerenveen", name: "Heerenveen", shortName: "HEE", colors: ["#0b4ea2", "#ffffff"], strength: "solid" },
-      { id: "vitesse", name: "Vitesse", shortName: "VIT", colors: ["#f6c800", "#000000"], strength: "solid" },
-      { id: "groningen", name: "Groningen", shortName: "GRO", colors: ["#009639", "#ffffff"], strength: "rising" },
-      { id: "nec", name: "NEC Nijmegen", shortName: "NEC", colors: ["#009639", "#e03c31"], strength: "rising" }
+      { id: "ajax", name: "Ajax", shortName: "AJA", colors: ["#ffffff", "#d20a0a"], strength: "contender", mentality: "Positive", marketValue: 360_000_000 },
+      { id: "psv", name: "PSV", shortName: "PSV", colors: ["#ff0000", "#ffffff"], strength: "contender", marketValue: 310_000_000 },
+      { id: "feyenoord", name: "Feyenoord", shortName: "FEY", colors: ["#ff0000", "#ffffff"], strength: "contender", marketValue: 320_000_000 },
+      { id: "az-alkmaar", name: "AZ Alkmaar", shortName: "AZ", colors: ["#e2001a", "#000000"], strength: "challenger", marketValue: 220_000_000 },
+      { id: "twente", name: "FC Twente", shortName: "TWE", colors: ["#d71920", "#ffffff"], strength: "challenger", marketValue: 180_000_000 },
+      { id: "utrecht", name: "FC Utrecht", shortName: "UTR", colors: ["#d71920", "#005ca7"], strength: "solid", marketValue: 120_000_000 },
+      { id: "heerenveen", name: "Heerenveen", shortName: "HEE", colors: ["#0b4ea2", "#ffffff"], strength: "solid", marketValue: 95_000_000 },
+      { id: "vitesse", name: "Vitesse", shortName: "VIT", colors: ["#f6c800", "#000000"], strength: "solid", marketValue: 85_000_000 },
+      { id: "groningen", name: "Groningen", shortName: "GRO", colors: ["#009639", "#ffffff"], strength: "rising", marketValue: 75_000_000 },
+      { id: "nec", name: "NEC Nijmegen", shortName: "NEC", colors: ["#009639", "#e03c31"], strength: "rising", marketValue: 70_000_000 }
     ]
   }),
   createSyntheticLeague({
@@ -339,16 +352,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 2,
     nationCode: "ENG",
     clubs: [
-      { id: "leicester", name: "Leicester City", shortName: "LEI", colors: ["#003090", "#fdb913"], strength: "challenger" },
-      { id: "leeds", name: "Leeds United", shortName: "LEE", colors: ["#fff200", "#1d428a"], strength: "challenger" },
-      { id: "southampton", name: "Southampton", shortName: "SOU", colors: ["#d71920", "#130c0e"], strength: "challenger" },
-      { id: "ipswich", name: "Ipswich Town", shortName: "IPS", colors: ["#003399", "#ffffff"], strength: "solid" },
-      { id: "watford", name: "Watford", shortName: "WAT", colors: ["#fbee23", "#ed2127"], strength: "solid" },
-      { id: "norwich", name: "Norwich", shortName: "NOR", colors: ["#fff200", "#007f3a"], strength: "solid" },
-      { id: "sunderland", name: "Sunderland", shortName: "SUN", colors: ["#ee2737", "#ffffff"], strength: "solid" },
-      { id: "middlesbrough", name: "Middlesbrough", shortName: "MID", colors: ["#da2128", "#ffffff"], strength: "solid" },
-      { id: "coventry", name: "Coventry City", shortName: "COV", colors: ["#8dc1e8", "#000000"], strength: "rising" },
-      { id: "west-brom", name: "West Brom", shortName: "WBA", colors: ["#0d2340", "#ffffff"], strength: "rising" }
+      { id: "leicester", name: "Leicester City", shortName: "LEI", colors: ["#003090", "#fdb913"], strength: "challenger", marketValue: 270_000_000 },
+      { id: "leeds", name: "Leeds United", shortName: "LEE", colors: ["#fff200", "#1d428a"], strength: "challenger", marketValue: 250_000_000 },
+      { id: "southampton", name: "Southampton", shortName: "SOU", colors: ["#d71920", "#130c0e"], strength: "challenger", marketValue: 230_000_000 },
+      { id: "ipswich", name: "Ipswich Town", shortName: "IPS", colors: ["#003399", "#ffffff"], strength: "solid", marketValue: 90_000_000 },
+      { id: "watford", name: "Watford", shortName: "WAT", colors: ["#fbee23", "#ed2127"], strength: "solid", marketValue: 95_000_000 },
+      { id: "norwich", name: "Norwich", shortName: "NOR", colors: ["#fff200", "#007f3a"], strength: "solid", marketValue: 110_000_000 },
+      { id: "sunderland", name: "Sunderland", shortName: "SUN", colors: ["#ee2737", "#ffffff"], strength: "solid", marketValue: 80_000_000 },
+      { id: "middlesbrough", name: "Middlesbrough", shortName: "MID", colors: ["#da2128", "#ffffff"], strength: "solid", marketValue: 85_000_000 },
+      { id: "coventry", name: "Coventry City", shortName: "COV", colors: ["#8dc1e8", "#000000"], strength: "rising", marketValue: 75_000_000 },
+      { id: "west-brom", name: "West Brom", shortName: "WBA", colors: ["#0d2340", "#ffffff"], strength: "rising", marketValue: 78_000_000 }
     ]
   }),
   createSyntheticLeague({
@@ -358,16 +371,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 2,
     nationCode: "ESP",
     clubs: [
-      { id: "leganes", name: "Leganés", shortName: "LEG", colors: ["#ffffff", "#005baa"], strength: "solid" },
-      { id: "espanyol", name: "Espanyol", shortName: "ESP", colors: ["#007ac2", "#ffffff"], strength: "solid" },
-      { id: "elche", name: "Elche", shortName: "ELC", colors: ["#0f7b3e", "#ffffff"], strength: "solid" },
-      { id: "oviedo", name: "Real Oviedo", shortName: "OVI", colors: ["#0055a4", "#ffc400"], strength: "solid" },
-      { id: "zaragoza", name: "Real Zaragoza", shortName: "ZAR", colors: ["#00529f", "#ffffff"], strength: "solid" },
-      { id: "levante", name: "Levante", shortName: "LEV", colors: ["#041c2c", "#9e1b32"], strength: "solid" },
-      { id: "malaga", name: "Málaga", shortName: "MAL", colors: ["#6bb3dd", "#ffffff"], strength: "rising" },
-      { id: "tenerife", name: "Tenerife", shortName: "TEN", colors: ["#1c3f95", "#ffffff"], strength: "rising" },
-      { id: "valladolid", name: "Valladolid", shortName: "VLL", colors: ["#4b0082", "#ffffff"], strength: "rising" },
-      { id: "sporting-gijon", name: "Sporting Gijón", shortName: "SPG", colors: ["#d50032", "#ffffff"], strength: "rising" }
+      { id: "leganes", name: "Leganés", shortName: "LEG", colors: ["#ffffff", "#005baa"], strength: "solid", marketValue: 45_000_000 },
+      { id: "espanyol", name: "Espanyol", shortName: "ESP", colors: ["#007ac2", "#ffffff"], strength: "solid", marketValue: 110_000_000 },
+      { id: "elche", name: "Elche", shortName: "ELC", colors: ["#0f7b3e", "#ffffff"], strength: "solid", marketValue: 60_000_000 },
+      { id: "oviedo", name: "Real Oviedo", shortName: "OVI", colors: ["#0055a4", "#ffc400"], strength: "solid", marketValue: 55_000_000 },
+      { id: "zaragoza", name: "Real Zaragoza", shortName: "ZAR", colors: ["#00529f", "#ffffff"], strength: "solid", marketValue: 58_000_000 },
+      { id: "levante", name: "Levante", shortName: "LEV", colors: ["#041c2c", "#9e1b32"], strength: "solid", marketValue: 65_000_000 },
+      { id: "malaga", name: "Málaga", shortName: "MAL", colors: ["#6bb3dd", "#ffffff"], strength: "rising", marketValue: 40_000_000 },
+      { id: "tenerife", name: "Tenerife", shortName: "TEN", colors: ["#1c3f95", "#ffffff"], strength: "rising", marketValue: 32_000_000 },
+      { id: "valladolid", name: "Valladolid", shortName: "VLL", colors: ["#4b0082", "#ffffff"], strength: "rising", marketValue: 85_000_000 },
+      { id: "sporting-gijon", name: "Sporting Gijón", shortName: "SPG", colors: ["#d50032", "#ffffff"], strength: "rising", marketValue: 45_000_000 }
     ]
   }),
   createSyntheticLeague({
@@ -377,16 +390,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 2,
     nationCode: "ITA",
     clubs: [
-      { id: "parma", name: "Parma", shortName: "PAR", colors: ["#002f87", "#ffdd00"], strength: "solid" },
-      { id: "palermo", name: "Palermo", shortName: "PAL", colors: ["#f5a8b8", "#000000"], strength: "solid" },
-      { id: "cagliari", name: "Cagliari", shortName: "CAG", colors: ["#003366", "#a50034"], strength: "solid" },
-      { id: "brescia", name: "Brescia", shortName: "BRE", colors: ["#0054a6", "#ffffff"], strength: "solid" },
-      { id: "como", name: "Como", shortName: "COM", colors: ["#003399", "#ffffff"], strength: "solid" },
-      { id: "pisa", name: "Pisa", shortName: "PIS", colors: ["#000000", "#0076bf"], strength: "rising" },
-      { id: "frosinone", name: "Frosinone", shortName: "FRO", colors: ["#004aad", "#ffda44"], strength: "rising" },
-      { id: "spezia", name: "Spezia", shortName: "SPE", colors: ["#000000", "#ffffff"], strength: "rising" },
-      { id: "reggina", name: "Reggina", shortName: "REG", colors: ["#800000", "#ffffff"], strength: "rising" },
-      { id: "lecce", name: "Lecce", shortName: "LEC", colors: ["#004aad", "#ffdd00"], strength: "rising" }
+      { id: "parma", name: "Parma", shortName: "PAR", colors: ["#002f87", "#ffdd00"], strength: "solid", marketValue: 65_000_000 },
+      { id: "palermo", name: "Palermo", shortName: "PAL", colors: ["#f5a8b8", "#000000"], strength: "solid", marketValue: 52_000_000 },
+      { id: "cagliari", name: "Cagliari", shortName: "CAG", colors: ["#003366", "#a50034"], strength: "solid", marketValue: 95_000_000 },
+      { id: "brescia", name: "Brescia", shortName: "BRE", colors: ["#0054a6", "#ffffff"], strength: "solid", marketValue: 45_000_000 },
+      { id: "como", name: "Como", shortName: "COM", colors: ["#003399", "#ffffff"], strength: "solid", marketValue: 60_000_000 },
+      { id: "pisa", name: "Pisa", shortName: "PIS", colors: ["#000000", "#0076bf"], strength: "rising", marketValue: 38_000_000 },
+      { id: "frosinone", name: "Frosinone", shortName: "FRO", colors: ["#004aad", "#ffda44"], strength: "rising", marketValue: 70_000_000 },
+      { id: "spezia", name: "Spezia", shortName: "SPE", colors: ["#000000", "#ffffff"], strength: "rising", marketValue: 75_000_000 },
+      { id: "reggina", name: "Reggina", shortName: "REG", colors: ["#800000", "#ffffff"], strength: "rising", marketValue: 35_000_000 },
+      { id: "lecce", name: "Lecce", shortName: "LEC", colors: ["#004aad", "#ffdd00"], strength: "rising", marketValue: 90_000_000 }
     ]
   }),
   createSyntheticLeague({
@@ -396,16 +409,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 2,
     nationCode: "GER",
     clubs: [
-      { id: "hamburg", name: "Hamburg", shortName: "HSV", colors: ["#005ca9", "#ffffff"], strength: "solid" },
-      { id: "schalke", name: "Schalke", shortName: "S04", colors: ["#0d47a1", "#ffffff"], strength: "solid" },
-      { id: "hertha", name: "Hertha BSC", shortName: "BSC", colors: ["#0041ab", "#ffffff"], strength: "solid" },
-      { id: "st-pauli", name: "St. Pauli", shortName: "STP", colors: ["#4b3621", "#ffffff"], strength: "solid" },
-      { id: "dusseldorf", name: "Fortuna Düsseldorf", shortName: "F95", colors: ["#d11241", "#ffffff"], strength: "solid" },
-      { id: "hannover", name: "Hannover 96", shortName: "H96", colors: ["#006633", "#000000"], strength: "solid" },
-      { id: "nurnberg", name: "Nürnberg", shortName: "FCN", colors: ["#800000", "#ffffff"], strength: "solid" },
-      { id: "paderborn", name: "Paderborn", shortName: "SCP", colors: ["#003399", "#ffffff"], strength: "rising" },
-      { id: "karlsruhe", name: "Karlsruhe", shortName: "KSC", colors: ["#0054a6", "#ffffff"], strength: "rising" },
-      { id: "holstein-kiel", name: "Holstein Kiel", shortName: "KIE", colors: ["#005ca9", "#ff0000"], strength: "rising" }
+      { id: "hamburg", name: "Hamburg", shortName: "HSV", colors: ["#005ca9", "#ffffff"], strength: "solid", marketValue: 70_000_000 },
+      { id: "schalke", name: "Schalke", shortName: "S04", colors: ["#0d47a1", "#ffffff"], strength: "solid", marketValue: 80_000_000 },
+      { id: "hertha", name: "Hertha BSC", shortName: "BSC", colors: ["#0041ab", "#ffffff"], strength: "solid", marketValue: 85_000_000 },
+      { id: "st-pauli", name: "St. Pauli", shortName: "STP", colors: ["#4b3621", "#ffffff"], strength: "solid", marketValue: 60_000_000 },
+      { id: "dusseldorf", name: "Fortuna Düsseldorf", shortName: "F95", colors: ["#d11241", "#ffffff"], strength: "solid", marketValue: 55_000_000 },
+      { id: "hannover", name: "Hannover 96", shortName: "H96", colors: ["#006633", "#000000"], strength: "solid", marketValue: 50_000_000 },
+      { id: "nurnberg", name: "Nürnberg", shortName: "FCN", colors: ["#800000", "#ffffff"], strength: "solid", marketValue: 45_000_000 },
+      { id: "paderborn", name: "Paderborn", shortName: "SCP", colors: ["#003399", "#ffffff"], strength: "rising", marketValue: 45_000_000 },
+      { id: "karlsruhe", name: "Karlsruhe", shortName: "KSC", colors: ["#0054a6", "#ffffff"], strength: "rising", marketValue: 38_000_000 },
+      { id: "holstein-kiel", name: "Holstein Kiel", shortName: "KIE", colors: ["#005ca9", "#ff0000"], strength: "rising", marketValue: 40_000_000 }
     ]
   }),
   createSyntheticLeague({
@@ -415,16 +428,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 2,
     nationCode: "FRA",
     clubs: [
-      { id: "auxerre", name: "Auxerre", shortName: "AJA", colors: ["#0f5bb3", "#ffffff"], strength: "solid" },
-      { id: "saint-etienne", name: "Saint-Étienne", shortName: "ASSE", colors: ["#00a55c", "#ffffff"], strength: "solid" },
-      { id: "angers", name: "Angers SCO", shortName: "ANG", colors: ["#000000", "#ffffff"], strength: "solid" },
-      { id: "caen", name: "Caen", shortName: "CAE", colors: ["#003087", "#e4002b"], strength: "solid" },
-      { id: "guingamp", name: "Guingamp", shortName: "GUI", colors: ["#d40000", "#000000"], strength: "solid" },
-      { id: "bastia", name: "Bastia", shortName: "BAS", colors: ["#0033a0", "#ffffff"], strength: "solid" },
-      { id: "dijon", name: "Dijon", shortName: "DIJ", colors: ["#d50032", "#ffffff"], strength: "rising" },
-      { id: "sochaux", name: "Sochaux", shortName: "SOC", colors: ["#f9d616", "#003a70"], strength: "rising" },
-      { id: "grenoble", name: "Grenoble", shortName: "GRE", colors: ["#00539f", "#ffffff"], strength: "rising" },
-      { id: "amiens", name: "Amiens", shortName: "AMI", colors: ["#6c757d", "#ffffff"], strength: "rising" }
+      { id: "auxerre", name: "Auxerre", shortName: "AJA", colors: ["#0f5bb3", "#ffffff"], strength: "solid", marketValue: 35_000_000 },
+      { id: "saint-etienne", name: "Saint-Étienne", shortName: "ASSE", colors: ["#00a55c", "#ffffff"], strength: "solid", marketValue: 50_000_000 },
+      { id: "angers", name: "Angers SCO", shortName: "ANG", colors: ["#000000", "#ffffff"], strength: "solid", marketValue: 40_000_000 },
+      { id: "caen", name: "Caen", shortName: "CAE", colors: ["#003087", "#e4002b"], strength: "solid", marketValue: 25_000_000 },
+      { id: "guingamp", name: "Guingamp", shortName: "GUI", colors: ["#d40000", "#000000"], strength: "solid", marketValue: 24_000_000 },
+      { id: "bastia", name: "Bastia", shortName: "BAS", colors: ["#0033a0", "#ffffff"], strength: "solid", marketValue: 22_000_000 },
+      { id: "dijon", name: "Dijon", shortName: "DIJ", colors: ["#d50032", "#ffffff"], strength: "rising", marketValue: 20_000_000 },
+      { id: "sochaux", name: "Sochaux", shortName: "SOC", colors: ["#f9d616", "#003a70"], strength: "rising", marketValue: 23_000_000 },
+      { id: "grenoble", name: "Grenoble", shortName: "GRE", colors: ["#00539f", "#ffffff"], strength: "rising", marketValue: 18_000_000 },
+      { id: "amiens", name: "Amiens", shortName: "AMI", colors: ["#6c757d", "#ffffff"], strength: "rising", marketValue: 30_000_000 }
     ]
   }),
   createSyntheticLeague({
@@ -434,16 +447,16 @@ const syntheticLeagues: LeagueData[] = [
     level: 2,
     nationCode: "NED",
     clubs: [
-      { id: "zwolle", name: "PEC Zwolle", shortName: "ZWO", colors: ["#007bc7", "#ffffff"], strength: "solid" },
-      { id: "willem-ii", name: "Willem II", shortName: "WII", colors: ["#a50034", "#132257"], strength: "solid" },
-      { id: "nac-breda", name: "NAC Breda", shortName: "NAC", colors: ["#ffcc00", "#000000"], strength: "solid" },
-      { id: "de-graafschap", name: "De Graafschap", shortName: "GRA", colors: ["#0b4ea2", "#ffffff"], strength: "solid" },
-      { id: "roda-jc", name: "Roda JC", shortName: "RJC", colors: ["#ffcd00", "#000000"], strength: "solid" },
-      { id: "den-haag", name: "ADO Den Haag", shortName: "ADO", colors: ["#007f3b", "#ffdd00"], strength: "rising" },
-      { id: "almere-city", name: "Almere City", shortName: "ALM", colors: ["#e32219", "#ffffff"], strength: "rising" },
-      { id: "excelsior", name: "Excelsior", shortName: "EXC", colors: ["#000000", "#ffffff"], strength: "rising" },
-      { id: "top-oss", name: "TOP Oss", shortName: "OSS", colors: ["#d50032", "#ffffff"], strength: "developing" },
-      { id: "telstar", name: "Telstar", shortName: "TEL", colors: ["#ffffff", "#f9a602"], strength: "developing" }
+      { id: "zwolle", name: "PEC Zwolle", shortName: "ZWO", colors: ["#007bc7", "#ffffff"], strength: "solid", marketValue: 25_000_000 },
+      { id: "willem-ii", name: "Willem II", shortName: "WII", colors: ["#a50034", "#132257"], strength: "solid", marketValue: 22_000_000 },
+      { id: "nac-breda", name: "NAC Breda", shortName: "NAC", colors: ["#ffcc00", "#000000"], strength: "solid", marketValue: 20_000_000 },
+      { id: "de-graafschap", name: "De Graafschap", shortName: "GRA", colors: ["#0b4ea2", "#ffffff"], strength: "solid", marketValue: 15_000_000 },
+      { id: "roda-jc", name: "Roda JC", shortName: "RJC", colors: ["#ffcd00", "#000000"], strength: "solid", marketValue: 14_000_000 },
+      { id: "den-haag", name: "ADO Den Haag", shortName: "ADO", colors: ["#007f3b", "#ffdd00"], strength: "rising", marketValue: 18_000_000 },
+      { id: "almere-city", name: "Almere City", shortName: "ALM", colors: ["#e32219", "#ffffff"], strength: "rising", marketValue: 16_000_000 },
+      { id: "excelsior", name: "Excelsior", shortName: "EXC", colors: ["#000000", "#ffffff"], strength: "rising", marketValue: 17_000_000 },
+      { id: "top-oss", name: "TOP Oss", shortName: "OSS", colors: ["#d50032", "#ffffff"], strength: "developing", marketValue: 8_000_000 },
+      { id: "telstar", name: "Telstar", shortName: "TEL", colors: ["#ffffff", "#f9a602"], strength: "developing", marketValue: 7_000_000 }
     ]
   }),
   // Third tiers for the top three countries

--- a/src/data/premierLeague.ts
+++ b/src/data/premierLeague.ts
@@ -1,0 +1,375 @@
+import type { Foot, Position } from "@domain/player/types";
+
+export interface PlayerTemplate {
+  id: string;
+  name: string;
+  age: number;
+  nationality: string;
+  foot: Foot;
+  positions: Position[];
+  currentAbility: number;
+  potentialAbility: number;
+  value: number;
+  wage: number;
+  contractYears: number;
+}
+
+export interface ClubTemplate {
+  id: string;
+  name: string;
+  shortName: string;
+  colors: string[];
+  formation: string;
+  mentality: "Balanced" | "Positive" | "Cautious";
+  tempo: number;
+  press: number;
+  rep: number;
+  transferBudget: number;
+  wageBudget: number;
+  players: PlayerTemplate[];
+}
+
+export interface LeagueData {
+  id: string;
+  name: string;
+  nation: string;
+  level: number;
+  clubs: ClubTemplate[];
+}
+
+export const premierLeagueData: LeagueData = {
+  id: "premier-league",
+  name: "Premier League",
+  nation: "England",
+  level: 1,
+  clubs: [
+    {
+      id: "arsenal",
+      name: "Arsenal",
+      shortName: "ARS",
+      colors: ["#EF0107", "#063672"],
+      formation: "4-3-3",
+      mentality: "Positive",
+      tempo: 68,
+      press: 70,
+      rep: 8600,
+      transferBudget: 70000000,
+      wageBudget: 2200000,
+      players: [
+        player("arsenal", "Aaron Ramsdale", 25, "ENG", "Right", ["GK"], 152, 158, 38000000, 120000, 4),
+        player("arsenal", "David Raya", 28, "ESP", "Right", ["GK"], 148, 150, 32000000, 110000, 3),
+        player("arsenal", "William Saliba", 23, "FRA", "Right", ["CB"], 165, 175, 70000000, 180000, 5),
+        player("arsenal", "Gabriel", 26, "BRA", "Left", ["CB"], 158, 162, 52000000, 150000, 4),
+        player("arsenal", "Ben White", 26, "ENG", "Right", ["RB", "CB"], 156, 160, 50000000, 160000, 4),
+        player("arsenal", "Oleksandr Zinchenko", 27, "UKR", "Left", ["LB", "CM"], 152, 156, 42000000, 140000, 4),
+        player("arsenal", "Declan Rice", 25, "ENG", "Right", ["DM", "CM"], 170, 178, 95000000, 240000, 6),
+        player("arsenal", "Martin Ødegaard", 25, "NOR", "Left", ["AM", "CM"], 168, 175, 85000000, 230000, 5),
+        player("arsenal", "Bukayo Saka", 22, "ENG", "Left", ["RW", "LW"], 172, 185, 110000000, 250000, 6),
+        player("arsenal", "Gabriel Martinelli", 22, "BRA", "Right", ["LW", "ST"], 160, 172, 76000000, 190000, 5),
+        player("arsenal", "Gabriel Jesus", 27, "BRA", "Right", ["ST", "RW"], 160, 164, 65000000, 200000, 4),
+        player("arsenal", "Kai Havertz", 24, "GER", "Left", ["AM", "ST"], 158, 165, 60000000, 210000, 4),
+        player("arsenal", "Jorginho", 32, "ITA", "Right", ["DM", "CM"], 150, 150, 22000000, 180000, 2),
+        player("arsenal", "Takehiro Tomiyasu", 25, "JPN", "Right", ["RB", "CB", "LB"], 150, 154, 28000000, 110000, 3),
+        player("arsenal", "Leandro Trossard", 29, "BEL", "Right", ["LW", "AM"], 154, 156, 36000000, 160000, 3)
+      ]
+    },
+    {
+      id: "man-city",
+      name: "Manchester City",
+      shortName: "MCI",
+      colors: ["#6CABDD", "#1C2C5B"],
+      formation: "4-3-3",
+      mentality: "Positive",
+      tempo: 64,
+      press: 72,
+      rep: 9300,
+      transferBudget: 90000000,
+      wageBudget: 2600000,
+      players: [
+        player("man-city", "Ederson", 30, "BRA", "Left", ["GK"], 162, 166, 65000000, 220000, 4),
+        player("man-city", "Stefan Ortega", 31, "GER", "Right", ["GK"], 148, 150, 18000000, 90000, 3),
+        player("man-city", "Kyle Walker", 34, "ENG", "Right", ["RB"], 158, 158, 18000000, 175000, 2),
+        player("man-city", "Rúben Dias", 27, "POR", "Right", ["CB"], 168, 170, 78000000, 230000, 5),
+        player("man-city", "John Stones", 29, "ENG", "Right", ["CB"], 162, 164, 52000000, 210000, 4),
+        player("man-city", "Josko Gvardiol", 22, "CRO", "Left", ["CB", "LB"], 165, 180, 82000000, 190000, 6),
+        player("man-city", "Rodri", 27, "ESP", "Right", ["DM"], 176, 180, 105000000, 260000, 6),
+        player("man-city", "Kevin De Bruyne", 32, "BEL", "Right", ["CM", "AM"], 180, 180, 90000000, 350000, 3),
+        player("man-city", "Phil Foden", 23, "ENG", "Left", ["AM", "RW"], 170, 182, 110000000, 250000, 5),
+        player("man-city", "Bernardo Silva", 29, "POR", "Left", ["RW", "AM", "CM"], 170, 170, 78000000, 300000, 4),
+        player("man-city", "Jack Grealish", 28, "ENG", "Right", ["LW"], 160, 162, 62000000, 300000, 4),
+        player("man-city", "Erling Haaland", 23, "NOR", "Left", ["ST"], 185, 195, 180000000, 400000, 5),
+        player("man-city", "Julián Álvarez", 24, "ARG", "Right", ["ST", "AM"], 164, 176, 82000000, 190000, 5),
+        player("man-city", "Matheus Nunes", 25, "POR", "Right", ["CM"], 156, 162, 42000000, 160000, 4),
+        player("man-city", "Manuel Akanji", 28, "SUI", "Right", ["CB", "RB"], 160, 162, 40000000, 180000, 4)
+      ]
+    },
+    {
+      id: "liverpool",
+      name: "Liverpool",
+      shortName: "LIV",
+      colors: ["#C8102E", "#00B2A9"],
+      formation: "4-3-3",
+      mentality: "Positive",
+      tempo: 70,
+      press: 74,
+      rep: 9000,
+      transferBudget: 65000000,
+      wageBudget: 2300000,
+      players: [
+        player("liverpool", "Alisson Becker", 31, "BRA", "Right", ["GK"], 170, 172, 78000000, 250000, 4),
+        player("liverpool", "Caoimhín Kelleher", 25, "IRL", "Right", ["GK"], 148, 154, 16000000, 60000, 4),
+        player("liverpool", "Virgil van Dijk", 32, "NED", "Right", ["CB"], 175, 175, 65000000, 220000, 3),
+        player("liverpool", "Ibrahima Konaté", 24, "FRA", "Right", ["CB"], 162, 172, 52000000, 170000, 4),
+        player("liverpool", "Trent Alexander-Arnold", 25, "ENG", "Right", ["RB", "CM"], 168, 176, 82000000, 220000, 4),
+        player("liverpool", "Andy Robertson", 29, "SCO", "Left", ["LB"], 160, 162, 45000000, 180000, 4),
+        player("liverpool", "Alexis Mac Allister", 25, "ARG", "Right", ["CM", "DM"], 160, 168, 52000000, 160000, 5),
+        player("liverpool", "Dominik Szoboszlai", 23, "HUN", "Right", ["AM", "CM"], 164, 176, 72000000, 200000, 5),
+        player("liverpool", "Curtis Jones", 23, "ENG", "Right", ["CM", "AM"], 150, 164, 26000000, 90000, 4),
+        player("liverpool", "Mohamed Salah", 31, "EGY", "Left", ["RW"], 178, 178, 100000000, 350000, 3),
+        player("liverpool", "Luis Díaz", 27, "COL", "Right", ["LW"], 162, 168, 62000000, 190000, 4),
+        player("liverpool", "Diogo Jota", 27, "POR", "Right", ["ST", "LW"], 160, 164, 55000000, 180000, 4),
+        player("liverpool", "Darwin Núñez", 24, "URU", "Right", ["ST"], 158, 172, 60000000, 210000, 5),
+        player("liverpool", "Wataru Endo", 31, "JPN", "Right", ["DM"], 150, 152, 15000000, 90000, 2),
+        player("liverpool", "Joe Gomez", 26, "ENG", "Right", ["CB", "RB"], 154, 158, 30000000, 120000, 4)
+      ]
+    },
+    {
+      id: "man-united",
+      name: "Manchester United",
+      shortName: "MUN",
+      colors: ["#DA291C", "#000000"],
+      formation: "4-2-3-1",
+      mentality: "Balanced",
+      tempo: 66,
+      press: 68,
+      rep: 9100,
+      transferBudget: 75000000,
+      wageBudget: 2500000,
+      players: [
+        player("man-united", "Andre Onana", 28, "CMR", "Right", ["GK"], 160, 164, 52000000, 210000, 5),
+        player("man-united", "Altay Bayındır", 26, "TUR", "Right", ["GK"], 145, 150, 12000000, 60000, 3),
+        player("man-united", "Lisandro Martínez", 26, "ARG", "Left", ["CB"], 160, 166, 52000000, 190000, 5),
+        player("man-united", "Raphaël Varane", 31, "FRA", "Right", ["CB"], 165, 165, 42000000, 300000, 2),
+        player("man-united", "Harry Maguire", 31, "ENG", "Right", ["CB"], 148, 148, 20000000, 190000, 3),
+        player("man-united", "Luke Shaw", 28, "ENG", "Left", ["LB"], 158, 160, 34000000, 200000, 4),
+        player("man-united", "Diogo Dalot", 25, "POR", "Right", ["RB", "LB"], 152, 158, 28000000, 140000, 4),
+        player("man-united", "Casemiro", 32, "BRA", "Right", ["DM"], 162, 162, 35000000, 300000, 3),
+        player("man-united", "Kobbie Mainoo", 19, "ENG", "Right", ["CM"], 148, 170, 26000000, 45000, 6),
+        player("man-united", "Bruno Fernandes", 29, "POR", "Right", ["AM"], 170, 170, 85000000, 270000, 5),
+        player("man-united", "Marcus Rashford", 26, "ENG", "Right", ["LW", "ST"], 166, 170, 92000000, 300000, 5),
+        player("man-united", "Alejandro Garnacho", 19, "ARG", "Right", ["LW"], 154, 176, 52000000, 90000, 6),
+        player("man-united", "Antony", 24, "BRA", "Left", ["RW"], 152, 160, 42000000, 200000, 5),
+        player("man-united", "Rasmus Højlund", 21, "DEN", "Left", ["ST"], 158, 178, 65000000, 180000, 6),
+        player("man-united", "Christian Eriksen", 32, "DEN", "Right", ["CM", "AM"], 156, 156, 26000000, 210000, 3)
+      ]
+    },
+    {
+      id: "chelsea",
+      name: "Chelsea",
+      shortName: "CHE",
+      colors: ["#034694", "#DBA111"],
+      formation: "4-2-3-1",
+      mentality: "Balanced",
+      tempo: 64,
+      press: 70,
+      rep: 8800,
+      transferBudget: 80000000,
+      wageBudget: 2400000,
+      players: [
+        player("chelsea", "Djordje Petrović", 24, "SRB", "Right", ["GK"], 150, 162, 24000000, 65000, 5),
+        player("chelsea", "Robert Sánchez", 26, "ESP", "Right", ["GK"], 150, 154, 25000000, 120000, 5),
+        player("chelsea", "Reece James", 24, "ENG", "Right", ["RB"], 162, 170, 70000000, 220000, 5),
+        player("chelsea", "Ben Chilwell", 27, "ENG", "Left", ["LB"], 156, 160, 45000000, 190000, 4),
+        player("chelsea", "Axel Disasi", 26, "FRA", "Right", ["CB"], 154, 158, 36000000, 160000, 5),
+        player("chelsea", "Levi Colwill", 21, "ENG", "Left", ["CB", "LB"], 156, 174, 55000000, 140000, 6),
+        player("chelsea", "Thiago Silva", 39, "BRA", "Right", ["CB"], 160, 160, 10000000, 160000, 1),
+        player("chelsea", "Moisés Caicedo", 22, "ECU", "Right", ["DM"], 162, 176, 90000000, 220000, 8),
+        player("chelsea", "Enzo Fernández", 23, "ARG", "Right", ["CM"], 162, 178, 85000000, 230000, 7),
+        player("chelsea", "Conor Gallagher", 24, "ENG", "Right", ["CM"], 154, 164, 42000000, 150000, 3),
+        player("chelsea", "Cole Palmer", 21, "ENG", "Left", ["RW", "AM"], 156, 174, 52000000, 160000, 6),
+        player("chelsea", "Raheem Sterling", 29, "ENG", "Right", ["LW", "RW"], 160, 160, 46000000, 300000, 4),
+        player("chelsea", "Mykhailo Mudryk", 23, "UKR", "Right", ["LW"], 152, 170, 42000000, 210000, 7),
+        player("chelsea", "Christopher Nkunku", 26, "FRA", "Right", ["ST", "AM"], 164, 170, 70000000, 250000, 5),
+        player("chelsea", "Nicolas Jackson", 22, "SEN", "Right", ["ST"], 154, 170, 42000000, 140000, 8)
+      ]
+    },
+    {
+      id: "tottenham",
+      name: "Tottenham Hotspur",
+      shortName: "TOT",
+      colors: ["#132257", "#FFFFFF"],
+      formation: "4-3-3",
+      mentality: "Positive",
+      tempo: 68,
+      press: 72,
+      rep: 8700,
+      transferBudget: 60000000,
+      wageBudget: 2100000,
+      players: [
+        player("tottenham", "Guglielmo Vicario", 27, "ITA", "Right", ["GK"], 156, 162, 32000000, 120000, 5),
+        player("tottenham", "Fraser Forster", 36, "ENG", "Right", ["GK"], 140, 140, 5000000, 70000, 2),
+        player("tottenham", "Cristian Romero", 26, "ARG", "Right", ["CB"], 164, 168, 62000000, 180000, 5),
+        player("tottenham", "Micky van de Ven", 23, "NED", "Left", ["CB"], 158, 176, 55000000, 160000, 6),
+        player("tottenham", "Pedro Porro", 24, "POR", "Right", ["RB"], 156, 166, 42000000, 140000, 5),
+        player("tottenham", "Destiny Udogie", 21, "ITA", "Left", ["LB"], 154, 172, 38000000, 120000, 6),
+        player("tottenham", "Yves Bissouma", 27, "MLI", "Right", ["DM", "CM"], 156, 160, 42000000, 150000, 4),
+        player("tottenham", "Pape Matar Sarr", 21, "SEN", "Right", ["CM"], 152, 170, 36000000, 90000, 6),
+        player("tottenham", "James Maddison", 27, "ENG", "Right", ["AM"], 166, 168, 65000000, 220000, 5),
+        player("tottenham", "Dejan Kulusevski", 24, "SWE", "Left", ["RW", "AM"], 160, 168, 58000000, 180000, 5),
+        player("tottenham", "Heung-min Son", 31, "KOR", "Both", ["LW", "ST"], 170, 170, 82000000, 290000, 4),
+        player("tottenham", "Richarlison", 26, "BRA", "Right", ["ST", "LW"], 158, 160, 52000000, 190000, 4),
+        player("tottenham", "Brennan Johnson", 22, "WAL", "Right", ["RW", "ST"], 152, 168, 36000000, 120000, 6),
+        player("tottenham", "Giovani Lo Celso", 27, "ARG", "Left", ["CM", "AM"], 154, 156, 28000000, 150000, 3),
+        player("tottenham", "Rodrigo Bentancur", 26, "URU", "Right", ["CM", "DM"], 158, 164, 42000000, 180000, 4)
+      ]
+    },
+    {
+      id: "newcastle",
+      name: "Newcastle United",
+      shortName: "NEW",
+      colors: ["#241F20", "#FFFFFF"],
+      formation: "4-3-3",
+      mentality: "Positive",
+      tempo: 66,
+      press: 70,
+      rep: 8400,
+      transferBudget: 55000000,
+      wageBudget: 2000000,
+      players: [
+        player("newcastle", "Nick Pope", 31, "ENG", "Right", ["GK"], 158, 160, 38000000, 130000, 4),
+        player("newcastle", "Martin Dúbravka", 35, "SVK", "Right", ["GK"], 148, 148, 9000000, 75000, 2),
+        player("newcastle", "Kieran Trippier", 33, "ENG", "Right", ["RB"], 158, 158, 26000000, 170000, 2),
+        player("newcastle", "Sven Botman", 24, "NED", "Left", ["CB"], 160, 170, 52000000, 140000, 5),
+        player("newcastle", "Fabian Schär", 32, "SUI", "Right", ["CB"], 154, 154, 18000000, 90000, 3),
+        player("newcastle", "Dan Burn", 31, "ENG", "Left", ["LB", "CB"], 152, 152, 16000000, 85000, 3),
+        player("newcastle", "Bruno Guimarães", 26, "BRA", "Right", ["CM", "DM"], 166, 174, 72000000, 200000, 5),
+        player("newcastle", "Sandro Tonali", 23, "ITA", "Right", ["CM", "DM"], 162, 178, 70000000, 220000, 6),
+        player("newcastle", "Joelinton", 27, "BRA", "Right", ["CM", "AM"], 156, 160, 42000000, 160000, 4),
+        player("newcastle", "Miguel Almirón", 30, "PAR", "Left", ["RW"], 154, 156, 28000000, 120000, 4),
+        player("newcastle", "Anthony Gordon", 23, "ENG", "Right", ["LW"], 156, 168, 48000000, 150000, 5),
+        player("newcastle", "Alexander Isak", 24, "SWE", "Right", ["ST"], 166, 176, 82000000, 200000, 5),
+        player("newcastle", "Callum Wilson", 32, "ENG", "Right", ["ST"], 158, 158, 26000000, 150000, 2),
+        player("newcastle", "Harvey Barnes", 26, "ENG", "Right", ["LW"], 156, 160, 42000000, 150000, 4),
+        player("newcastle", "Tino Livramento", 21, "ENG", "Right", ["RB"], 150, 168, 28000000, 90000, 6)
+      ]
+    },
+    {
+      id: "aston-villa",
+      name: "Aston Villa",
+      shortName: "AVL",
+      colors: ["#670E36", "#95BFE5"],
+      formation: "4-2-3-1",
+      mentality: "Positive",
+      tempo: 64,
+      press: 66,
+      rep: 8200,
+      transferBudget: 45000000,
+      wageBudget: 1700000,
+      players: [
+        player("aston-villa", "Emiliano Martínez", 31, "ARG", "Right", ["GK"], 166, 166, 60000000, 180000, 4),
+        player("aston-villa", "Robin Olsen", 34, "SWE", "Right", ["GK"], 142, 142, 5000000, 60000, 2),
+        player("aston-villa", "Ezri Konsa", 26, "ENG", "Right", ["CB"], 156, 160, 32000000, 120000, 4),
+        player("aston-villa", "Pau Torres", 27, "ESP", "Left", ["CB"], 158, 164, 42000000, 160000, 5),
+        player("aston-villa", "Lucas Digne", 30, "FRA", "Left", ["LB"], 154, 154, 22000000, 150000, 3),
+        player("aston-villa", "Matty Cash", 26, "POL", "Right", ["RB"], 152, 154, 22000000, 120000, 4),
+        player("aston-villa", "Douglas Luiz", 25, "BRA", "Right", ["DM", "CM"], 160, 168, 52000000, 150000, 4),
+        player("aston-villa", "Boubacar Kamara", 24, "FRA", "Right", ["DM", "CB"], 158, 170, 48000000, 160000, 5),
+        player("aston-villa", "John McGinn", 29, "SCO", "Left", ["CM", "AM"], 156, 156, 32000000, 130000, 4),
+        player("aston-villa", "Moussa Diaby", 24, "FRA", "Left", ["RW", "LW"], 160, 170, 60000000, 180000, 5),
+        player("aston-villa", "Leon Bailey", 26, "JAM", "Left", ["RW", "LW"], 156, 160, 38000000, 140000, 4),
+        player("aston-villa", "Ollie Watkins", 28, "ENG", "Right", ["ST"], 164, 166, 62000000, 200000, 5),
+        player("aston-villa", "Youri Tielemans", 27, "BEL", "Right", ["CM"], 156, 160, 30000000, 160000, 4),
+        player("aston-villa", "Jacob Ramsey", 22, "ENG", "Right", ["AM", "CM"], 152, 170, 32000000, 90000, 6),
+        player("aston-villa", "Matheus Luiz", 23, "BRA", "Right", ["CM"], 148, 164, 22000000, 80000, 5)
+      ]
+    },
+    {
+      id: "brighton",
+      name: "Brighton & Hove Albion",
+      shortName: "BHA",
+      colors: ["#0057B8", "#FFFFFF"],
+      formation: "4-2-3-1",
+      mentality: "Positive",
+      tempo: 68,
+      press: 70,
+      rep: 7800,
+      transferBudget: 42000000,
+      wageBudget: 1600000,
+      players: [
+        player("brighton", "Bart Verbruggen", 21, "NED", "Right", ["GK"], 150, 168, 28000000, 65000, 6),
+        player("brighton", "Jason Steele", 33, "ENG", "Right", ["GK"], 145, 145, 4000000, 60000, 2),
+        player("brighton", "Lewis Dunk", 32, "ENG", "Right", ["CB"], 156, 156, 20000000, 90000, 3),
+        player("brighton", "Jan Paul van Hecke", 23, "NED", "Right", ["CB"], 150, 162, 20000000, 70000, 5),
+        player("brighton", "Pervis Estupiñán", 26, "ECU", "Left", ["LB"], 156, 164, 36000000, 120000, 4),
+        player("brighton", "Tariq Lamptey", 23, "GHA", "Right", ["RB"], 150, 162, 22000000, 90000, 4),
+        player("brighton", "Billy Gilmour", 22, "SCO", "Right", ["CM"], 150, 168, 24000000, 90000, 5),
+        player("brighton", "Pascal Groß", 32, "GER", "Right", ["AM", "CM"], 160, 160, 26000000, 110000, 3),
+        player("brighton", "João Pedro", 22, "BRA", "Right", ["ST", "AM"], 156, 172, 42000000, 140000, 6),
+        player("brighton", "Solly March", 29, "ENG", "Left", ["RW", "LW"], 156, 156, 26000000, 110000, 4),
+        player("brighton", "Kaoru Mitoma", 26, "JPN", "Right", ["LW"], 160, 166, 52000000, 170000, 4),
+        player("brighton", "Evan Ferguson", 19, "IRL", "Right", ["ST"], 156, 180, 48000000, 90000, 6),
+        player("brighton", "Adam Lallana", 35, "ENG", "Right", ["AM"], 148, 148, 6000000, 70000, 2),
+        player("brighton", "Simon Adingra", 22, "CIV", "Right", ["RW", "LW"], 152, 168, 32000000, 85000, 5),
+        player("brighton", "Facundo Buonanotte", 19, "ARG", "Left", ["AM", "RW"], 148, 170, 26000000, 60000, 6)
+      ]
+    },
+    {
+      id: "west-ham",
+      name: "West Ham United",
+      shortName: "WHU",
+      colors: ["#7A263A", "#1BB1E7"],
+      formation: "4-2-3-1",
+      mentality: "Balanced",
+      tempo: 62,
+      press: 64,
+      rep: 7800,
+      transferBudget: 38000000,
+      wageBudget: 1500000,
+      players: [
+        player("west-ham", "Alphonse Areola", 31, "FRA", "Right", ["GK"], 156, 158, 28000000, 140000, 4),
+        player("west-ham", "Lukasz Fabianski", 38, "POL", "Right", ["GK"], 148, 148, 3000000, 80000, 1),
+        player("west-ham", "Kurt Zouma", 29, "FRA", "Right", ["CB"], 154, 154, 26000000, 150000, 3),
+        player("west-ham", "Nayef Aguerd", 28, "MAR", "Left", ["CB"], 154, 160, 32000000, 140000, 4),
+        player("west-ham", "Vladimir Coufal", 31, "CZE", "Right", ["RB"], 150, 150, 14000000, 90000, 2),
+        player("west-ham", "Emerson Palmieri", 29, "ITA", "Left", ["LB"], 150, 150, 16000000, 85000, 3),
+        player("west-ham", "Edson Álvarez", 26, "MEX", "Right", ["DM", "CB"], 156, 162, 42000000, 150000, 5),
+        player("west-ham", "James Ward-Prowse", 29, "ENG", "Right", ["CM", "AM"], 156, 156, 32000000, 160000, 4),
+        player("west-ham", "Lucas Paquetá", 26, "BRA", "Right", ["AM", "CM"], 164, 170, 72000000, 220000, 5),
+        player("west-ham", "Jarrod Bowen", 27, "ENG", "Left", ["RW", "ST"], 160, 162, 56000000, 190000, 4),
+        player("west-ham", "Michail Antonio", 34, "JAM", "Right", ["ST"], 150, 150, 8000000, 110000, 2),
+        player("west-ham", "Mohammed Kudus", 23, "GHA", "Left", ["AM", "RW"], 160, 174, 60000000, 180000, 5),
+        player("west-ham", "Saïd Benrahma", 28, "ALG", "Right", ["LW", "AM"], 154, 156, 28000000, 140000, 3),
+        player("west-ham", "Tomáš Souček", 29, "CZE", "Right", ["CM", "DM"], 154, 154, 26000000, 120000, 4),
+        player("west-ham", "Pablo Fornals", 28, "ESP", "Right", ["AM", "CM"], 152, 152, 22000000, 130000, 3)
+      ]
+    }
+  ]
+};
+
+function player(
+  club: string,
+  name: string,
+  age: number,
+  nationality: string,
+  foot: Foot,
+  positions: Position[],
+  currentAbility: number,
+  potentialAbility: number,
+  value: number,
+  wage: number,
+  contractYears: number
+): PlayerTemplate {
+  return {
+    id: `${club}-${name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")}`,
+    name,
+    age,
+    nationality,
+    foot,
+    positions,
+    currentAbility,
+    potentialAbility,
+    value,
+    wage,
+    contractYears
+  };
+}

--- a/src/data/premierLeague.ts
+++ b/src/data/premierLeague.ts
@@ -24,6 +24,7 @@ export interface ClubTemplate {
   tempo: number;
   press: number;
   rep: number;
+  marketValue?: number;
   transferBudget: number;
   wageBudget: number;
   players: PlayerTemplate[];
@@ -53,6 +54,7 @@ export const premierLeagueData: LeagueData = {
       tempo: 68,
       press: 70,
       rep: 8600,
+      marketValue: 1_010_000_000,
       transferBudget: 70000000,
       wageBudget: 2200000,
       players: [
@@ -83,6 +85,7 @@ export const premierLeagueData: LeagueData = {
       tempo: 64,
       press: 72,
       rep: 9300,
+      marketValue: 1_200_000_000,
       transferBudget: 90000000,
       wageBudget: 2600000,
       players: [
@@ -113,6 +116,7 @@ export const premierLeagueData: LeagueData = {
       tempo: 70,
       press: 74,
       rep: 9000,
+      marketValue: 960_000_000,
       transferBudget: 65000000,
       wageBudget: 2300000,
       players: [
@@ -143,6 +147,7 @@ export const premierLeagueData: LeagueData = {
       tempo: 66,
       press: 68,
       rep: 9100,
+      marketValue: 870_000_000,
       transferBudget: 75000000,
       wageBudget: 2500000,
       players: [
@@ -173,6 +178,7 @@ export const premierLeagueData: LeagueData = {
       tempo: 64,
       press: 70,
       rep: 8800,
+      marketValue: 860_000_000,
       transferBudget: 80000000,
       wageBudget: 2400000,
       players: [
@@ -203,6 +209,7 @@ export const premierLeagueData: LeagueData = {
       tempo: 68,
       press: 72,
       rep: 8700,
+      marketValue: 780_000_000,
       transferBudget: 60000000,
       wageBudget: 2100000,
       players: [
@@ -233,6 +240,7 @@ export const premierLeagueData: LeagueData = {
       tempo: 66,
       press: 70,
       rep: 8400,
+      marketValue: 720_000_000,
       transferBudget: 55000000,
       wageBudget: 2000000,
       players: [
@@ -263,6 +271,7 @@ export const premierLeagueData: LeagueData = {
       tempo: 64,
       press: 66,
       rep: 8200,
+      marketValue: 620_000_000,
       transferBudget: 45000000,
       wageBudget: 1700000,
       players: [
@@ -293,6 +302,7 @@ export const premierLeagueData: LeagueData = {
       tempo: 68,
       press: 70,
       rep: 7800,
+      marketValue: 520_000_000,
       transferBudget: 42000000,
       wageBudget: 1600000,
       players: [
@@ -323,6 +333,7 @@ export const premierLeagueData: LeagueData = {
       tempo: 62,
       press: 64,
       rep: 7800,
+      marketValue: 480_000_000,
       transferBudget: 38000000,
       wageBudget: 1500000,
       players: [

--- a/src/domain/club/types.ts
+++ b/src/domain/club/types.ts
@@ -1,0 +1,33 @@
+import type { ID } from "@core/types";
+import type { Position } from "@domain/player/types";
+
+export interface TacticsProfile {
+  formation: string;
+  mentality: "Balanced" | "Positive" | "Cautious";
+  tempo: number;
+  press: number;
+}
+
+export interface Club {
+  id: ID;
+  name: string;
+  shortName: string;
+  leagueId: ID;
+  roster: ID[];
+  colors: string[];
+  tactics: TacticsProfile;
+  rep: number;
+}
+
+export interface LineupSlot {
+  position: Position;
+  playerId: ID;
+}
+
+export interface League {
+  id: ID;
+  name: string;
+  nation: string;
+  clubIds: ID[];
+  level: number;
+}

--- a/src/domain/club/types.ts
+++ b/src/domain/club/types.ts
@@ -17,6 +17,9 @@ export interface Club {
   colors: string[];
   tactics: TacticsProfile;
   rep: number;
+  transferBudget: number;
+  wageBudget: number;
+  wageCommitment: number;
 }
 
 export interface LineupSlot {

--- a/src/domain/club/types.ts
+++ b/src/domain/club/types.ts
@@ -17,6 +17,7 @@ export interface Club {
   colors: string[];
   tactics: TacticsProfile;
   rep: number;
+  marketValue: number;
   transferBudget: number;
   wageBudget: number;
   wageCommitment: number;

--- a/src/domain/match/types.ts
+++ b/src/domain/match/types.ts
@@ -1,0 +1,39 @@
+import type { ID } from "@core/types";
+import type { DateStamp } from "@core/types";
+import type { PlayerMatchStats } from "@domain/player/types";
+
+export interface Fixture {
+  id: ID;
+  competitionId: ID;
+  homeId: ID;
+  awayId: ID;
+  date: DateStamp;
+  played: boolean;
+  matchId?: ID;
+}
+
+export interface MatchEvent {
+  minute: number;
+  type: "Kickoff" | "Goal" | "Shot" | "Foul" | "HalfTime" | "FullTime";
+  description: string;
+  teamId?: ID;
+  playerId?: ID;
+}
+
+export interface MatchTeamStats {
+  clubId: ID;
+  goals: number;
+  shots: number;
+  shotsOnTarget: number;
+  possession: number;
+}
+
+export interface Match {
+  id: ID;
+  fixtureId: ID;
+  events: MatchEvent[];
+  stats: MatchTeamStats[];
+  playerStats: PlayerMatchStats[];
+  state: "Scheduled" | "Live" | "Complete";
+  score: { home: number; away: number };
+}

--- a/src/domain/player/types.ts
+++ b/src/domain/player/types.ts
@@ -1,0 +1,76 @@
+import type { ID } from "@core/types";
+
+export type Foot = "Left" | "Right" | "Both";
+export type Position =
+  | "GK"
+  | "RB"
+  | "CB"
+  | "LB"
+  | "DM"
+  | "CM"
+  | "AM"
+  | "RW"
+  | "LW"
+  | "ST";
+
+export interface Attributes {
+  finishing: number;
+  firstTouch: number;
+  passing: number;
+  crossing: number;
+  dribbling: number;
+  heading: number;
+  tackling: number;
+  marking: number;
+  longShots: number;
+  setPieces: number;
+  decisions: number;
+  anticipation: number;
+  vision: number;
+  workRate: number;
+  bravery: number;
+  composure: number;
+  offTheBall: number;
+  positioning: number;
+  leadership: number;
+  flair: number;
+  pace: number;
+  acceleration: number;
+  strength: number;
+  stamina: number;
+  agility: number;
+  jumping: number;
+  handling: number;
+  reflexes: number;
+  aerial: number;
+  distribution: number;
+}
+
+export interface Player {
+  id: ID;
+  name: string;
+  age: number;
+  nationality: string;
+  foot: Foot;
+  positions: Position[];
+  attributes: Attributes;
+  currentAbility: number;
+  potentialAbility: number;
+  morale: number;
+  condition: number;
+  sharpness: number;
+  value: number;
+  clubId: ID | null;
+  form: number[];
+}
+
+export interface PlayerMatchStats {
+  playerId: ID;
+  rating: number;
+  minutes: number;
+  goals: number;
+  assists: number;
+  shots: number;
+  passesCompleted: number;
+  tacklesWon: number;
+}

--- a/src/domain/player/types.ts
+++ b/src/domain/player/types.ts
@@ -60,8 +60,11 @@ export interface Player {
   condition: number;
   sharpness: number;
   value: number;
+  wage: number;
+  contractExpirySeason: number;
   clubId: ID | null;
   form: number[];
+  transferListed?: boolean;
 }
 
 export interface PlayerMatchStats {

--- a/src/domain/transfer/types.ts
+++ b/src/domain/transfer/types.ts
@@ -1,0 +1,18 @@
+import type { DateStamp, ID } from "@core/types";
+
+export interface TransferListing {
+  playerId: ID;
+  fromClubId: ID;
+  askingPrice: number;
+  interestedClubIds: ID[];
+  status: "Available" | "Negotiating" | "Completed";
+}
+
+export interface TransferHistoryEntry {
+  id: ID;
+  playerId: ID;
+  fromClubId: ID;
+  toClubId: ID;
+  fee: number;
+  date: DateStamp;
+}

--- a/src/engine/sim/schedule.ts
+++ b/src/engine/sim/schedule.ts
@@ -1,0 +1,46 @@
+import type { DateStamp, ID } from "@core/types";
+import { nextDay } from "@core/types";
+import type { Club } from "@domain/club/types";
+import type { Fixture } from "@domain/match/types";
+
+export function buildSchedule(clubs: Club[], competitionId: ID, start: DateStamp): Fixture[] {
+  const ordering = [...clubs];
+  const fixtures: Fixture[] = [];
+  let dateCursor = { ...start };
+  let fixtureId = 1;
+
+  for (let round = 0; round < ordering.length - 1; round += 1) {
+    for (let i = 0; i < ordering.length / 2; i += 1) {
+      const home = ordering[i];
+      const away = ordering[ordering.length - 1 - i];
+      fixtures.push({
+        id: `fixture-${fixtureId++}`,
+        competitionId,
+        homeId: home.id,
+        awayId: away.id,
+        date: { ...dateCursor },
+        played: false
+      });
+    }
+    dateCursor = nextDay(dateCursor);
+    rotate(ordering);
+  }
+
+  // reverse fixtures
+  const reverseFixtures = fixtures.map((fixture) => ({
+    ...fixture,
+    id: `fixture-${fixtureId++}`,
+    homeId: fixture.awayId,
+    awayId: fixture.homeId,
+    date: nextDay(fixture.date)
+  }));
+
+  return [...fixtures, ...reverseFixtures];
+}
+
+function rotate(clubs: Club[]): void {
+  const fixed = clubs[0];
+  const rest = clubs.slice(1);
+  rest.unshift(rest.pop()!);
+  clubs.splice(0, clubs.length, fixed, ...rest);
+}

--- a/src/engine/sim/simpleMatch.ts
+++ b/src/engine/sim/simpleMatch.ts
@@ -123,19 +123,20 @@ function runSimulation(input: MatchInput, rng: ReturnType<typeof createRNG>) {
     possession: Math.round(awayPossession)
   };
 
-  const playerStats: PlayerMatchStats[] = [...input.homePlayers, ...input.awayPlayers].map(
-    (player) => ({
+  const playerStats: PlayerMatchStats[] = [...input.homePlayers, ...input.awayPlayers].map((player) => {
+    const abilityBoost = (player.currentAbility - 140) / 80;
+    const rating = clamp(6.2 + rng.next() * 1.6 + abilityBoost, 5.0, 10);
+    return {
       playerId: player.id,
-      rating: 6.5 + rng.next() * 1.5 + (player.currentAbility - 40) / 60,
+      rating,
       minutes: 90,
-      goals:
-        events.filter((event) => event.type === "Goal" && event.playerId === player.id).length,
+      goals: events.filter((event) => event.type === "Goal" && event.playerId === player.id).length,
       assists: 0,
       shots: Math.round(rng.next() * 3),
       passesCompleted: Math.round(rng.next() * 40),
       tacklesWon: Math.round(rng.next() * 5)
-    })
-  );
+    };
+  });
 
   return {
     homeScore: homeGoals,

--- a/src/engine/sim/simpleMatch.ts
+++ b/src/engine/sim/simpleMatch.ts
@@ -1,0 +1,172 @@
+import { createRNG, deriveSeed } from "@core/rng";
+import type { RNGSeed } from "@core/types";
+import type { Fixture, Match, MatchEvent, MatchTeamStats } from "@domain/match/types";
+import type { Player, PlayerMatchStats } from "@domain/player/types";
+import type { World } from "@app/world";
+
+export interface MatchInput {
+  fixture: Fixture;
+  homePlayers: Player[];
+  awayPlayers: Player[];
+}
+
+export function simulateMatch(world: World, fixture: Fixture, seed: RNGSeed): Match {
+  const derived = deriveSeed(seed, Number(fixture.id.replace(/\D/g, "")) || 0);
+  const rng = createRNG(derived);
+  const homePlayers = pickStartingXI(world, fixture.homeId);
+  const awayPlayers = pickStartingXI(world, fixture.awayId);
+
+  const input: MatchInput = { fixture, homePlayers, awayPlayers };
+  const { homeScore, awayScore, events, homeStats, awayStats, playerStats } = runSimulation(
+    input,
+    rng
+  );
+
+  return {
+    id: `match-${fixture.id}`,
+    fixtureId: fixture.id,
+    events,
+    stats: [homeStats, awayStats],
+    playerStats,
+    state: "Complete",
+    score: { home: homeScore, away: awayScore }
+  };
+}
+
+function runSimulation(input: MatchInput, rng: ReturnType<typeof createRNG>) {
+  const totalMinutes = 90;
+  const events: MatchEvent[] = [{ minute: 0, type: "Kickoff", description: "Kick-off" }];
+
+  let homePossession = 50;
+  let awayPossession = 50;
+  const homeStrength = squadStrength(input.homePlayers);
+  const awayStrength = squadStrength(input.awayPlayers);
+  const strengthTotal = homeStrength + awayStrength;
+
+  const homeShotRate = 8 + Math.round((homeStrength / strengthTotal) * 6);
+  const awayShotRate = 8 + Math.round((awayStrength / strengthTotal) * 6);
+
+  let homeGoals = 0;
+  let awayGoals = 0;
+
+  for (let minute = 5; minute <= totalMinutes; minute += 5) {
+    const possessionSwing = rng.next() * 10 - 5;
+    homePossession = clamp(homePossession + possessionSwing, 35, 65);
+    awayPossession = 100 - homePossession;
+
+    if (rng.next() < homeShotRate / 100) {
+      const shooter = rng.pick(input.homePlayers);
+      const shotQuality = shootingQuality(shooter);
+      const chance = 0.04 + shotQuality * 0.06 + homeStrength / (strengthTotal * 2);
+      events.push({
+        minute,
+        type: "Shot",
+        description: `${shooter.name} tries his luck from distance for the home side` ,
+        teamId: input.fixture.homeId,
+        playerId: shooter.id
+      });
+      if (rng.next() < chance) {
+        homeGoals += 1;
+        events.push({
+          minute,
+          type: "Goal",
+          description: `${shooter.name} scores for the hosts!`,
+          teamId: input.fixture.homeId,
+          playerId: shooter.id
+        });
+      }
+    }
+
+    if (rng.next() < awayShotRate / 100) {
+      const shooter = rng.pick(input.awayPlayers);
+      const shotQuality = shootingQuality(shooter);
+      const chance = 0.04 + shotQuality * 0.06 + awayStrength / (strengthTotal * 2);
+      events.push({
+        minute,
+        type: "Shot",
+        description: `${shooter.name} lines up a chance for the visitors`,
+        teamId: input.fixture.awayId,
+        playerId: shooter.id
+      });
+      if (rng.next() < chance) {
+        awayGoals += 1;
+        events.push({
+          minute,
+          type: "Goal",
+          description: `${shooter.name} finds the net for the visitors!`,
+          teamId: input.fixture.awayId,
+          playerId: shooter.id
+        });
+      }
+    }
+
+    if (minute === 45) {
+      events.push({ minute, type: "HalfTime", description: "Half-time whistle" });
+    }
+  }
+
+  events.push({ minute: 90, type: "FullTime", description: "Full-time" });
+
+  const homeStats: MatchTeamStats = {
+    clubId: input.fixture.homeId,
+    goals: homeGoals,
+    shots: Math.round(homeShotRate * 1.2),
+    shotsOnTarget: Math.round(homeShotRate * 0.6),
+    possession: Math.round(homePossession)
+  };
+
+  const awayStats: MatchTeamStats = {
+    clubId: input.fixture.awayId,
+    goals: awayGoals,
+    shots: Math.round(awayShotRate * 1.2),
+    shotsOnTarget: Math.round(awayShotRate * 0.6),
+    possession: Math.round(awayPossession)
+  };
+
+  const playerStats: PlayerMatchStats[] = [...input.homePlayers, ...input.awayPlayers].map(
+    (player) => ({
+      playerId: player.id,
+      rating: 6.5 + rng.next() * 1.5 + (player.currentAbility - 40) / 60,
+      minutes: 90,
+      goals:
+        events.filter((event) => event.type === "Goal" && event.playerId === player.id).length,
+      assists: 0,
+      shots: Math.round(rng.next() * 3),
+      passesCompleted: Math.round(rng.next() * 40),
+      tacklesWon: Math.round(rng.next() * 5)
+    })
+  );
+
+  return {
+    homeScore: homeGoals,
+    awayScore: awayGoals,
+    events,
+    homeStats,
+    awayStats,
+    playerStats
+  };
+}
+
+function squadStrength(players: Player[]): number {
+  return players.reduce((acc, p) => acc + p.currentAbility, 0);
+}
+
+function shootingQuality(player: Player): number {
+  const { finishing, composure, offTheBall } = player.attributes;
+  return (finishing + composure + offTheBall) / 60;
+}
+
+function pickStartingXI(world: World, clubId: string): Player[] {
+  const club = world.clubs.find((c) => c.id === clubId);
+  if (!club) {
+    throw new Error(`Club not found: ${clubId}`);
+  }
+  return club.roster
+    .map((playerId) => world.players.find((p) => p.id === playerId)!)
+    .sort((a, b) => b.currentAbility - a.currentAbility)
+    .slice(0, 11);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,209 @@
+import { GameStore, randomSeed } from "@app/store";
+import type { World } from "@app/world";
+import { drawPitch } from "@ui/components/pitch";
+import { renderDashboard } from "@ui/screens/dashboard";
+import { renderMatch } from "@ui/screens/match";
+import { renderSquad } from "@ui/screens/squad";
+import { renderTactics } from "@ui/screens/tactics";
+
+type Theme = "light" | "dark";
+
+const THEME_STORAGE_KEY = "hfm-theme";
+
+function getStoredTheme(): Theme | null {
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") {
+      return stored;
+    }
+  } catch {
+    // ignore storage failures
+  }
+  return null;
+}
+
+function detectSystemTheme(): Theme {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function persistTheme(theme: Theme): void {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // ignore storage failures
+  }
+}
+
+const store = new GameStore(randomSeed());
+const app = document.getElementById("app");
+
+const storedTheme = getStoredTheme();
+let userSelectedTheme = storedTheme !== null;
+let activeTheme: Theme = storedTheme ?? detectSystemTheme();
+
+const themeToggle = document.createElement("button");
+themeToggle.type = "button";
+themeToggle.classList.add("ghost");
+
+function applyTheme(theme: Theme, persist = true): void {
+  activeTheme = theme;
+  document.documentElement.dataset.theme = theme;
+  themeToggle.textContent = theme === "dark" ? "☀️ Light" : "🌙 Dark";
+  themeToggle.setAttribute(
+    "aria-label",
+    theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
+  );
+  if (persist) {
+    persistTheme(theme);
+  }
+}
+
+applyTheme(activeTheme, userSelectedTheme);
+
+const systemThemeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+systemThemeQuery.addEventListener("change", (event) => {
+  if (!userSelectedTheme) {
+    applyTheme(event.matches ? "dark" : "light", false);
+  }
+});
+
+if (!app) {
+  throw new Error("App container not found");
+}
+
+app.className = "shell";
+
+const header = document.createElement("header");
+header.className = "topbar glass";
+
+const nav = document.createElement("aside");
+nav.className = "sidebar glass";
+
+const main = document.createElement("main");
+main.className = "content";
+
+const titleGroup = document.createElement("div");
+titleGroup.className = "title-group";
+
+const title = document.createElement("h1");
+title.className = "page-title";
+
+const subtitle = document.createElement("p");
+subtitle.className = "page-subtitle";
+
+const controls = document.createElement("div");
+controls.className = "controls";
+
+themeToggle.addEventListener("click", () => {
+  userSelectedTheme = true;
+  applyTheme(activeTheme === "dark" ? "light" : "dark");
+});
+
+const advanceDayButton = document.createElement("button");
+advanceDayButton.textContent = "Advance Day";
+advanceDayButton.className = "primary";
+advanceDayButton.addEventListener("click", () => {
+  const summary = store.dispatch({ type: "ADVANCE_DAY" });
+  if (summary) {
+    summary.messages.forEach((message) => notify(message));
+  }
+});
+
+const advanceWeekButton = document.createElement("button");
+advanceWeekButton.textContent = "Advance 7 Days";
+advanceWeekButton.addEventListener("click", () => {
+  const summary = store.dispatch({ type: "ADVANCE_DAYS", payload: { days: 7 } });
+  if (summary) {
+    summary.messages.forEach((message) => notify(message));
+  }
+});
+
+controls.append(themeToggle, advanceDayButton, advanceWeekButton);
+
+const navTitle = document.createElement("div");
+navTitle.className = "brand";
+navTitle.innerHTML = `<span class="brand-mark">⚽</span><span class="brand-text">Manager</span>`;
+nav.append(navTitle);
+
+const views: Record<string, (world: World) => string> = {
+  dashboard: renderDashboard,
+  squad: renderSquad,
+  tactics: renderTactics,
+  match: renderMatch
+};
+
+let activeView: keyof typeof views = "dashboard";
+
+Object.entries(views).forEach(([key]) => {
+  const button = document.createElement("button");
+  button.textContent = key.charAt(0).toUpperCase() + key.slice(1);
+  button.dataset.view = key;
+  if (key === activeView) button.classList.add("active");
+  button.addEventListener("click", () => {
+    activeView = key as keyof typeof views;
+    updateNavigation();
+    render();
+  });
+  nav.append(button);
+});
+
+titleGroup.append(title, subtitle);
+header.append(titleGroup, controls);
+
+const workspace = document.createElement("div");
+workspace.className = "workspace";
+workspace.append(main);
+
+app.append(nav, header, workspace);
+
+function formatDate(date: World["date"]): string {
+  return `Season ${date.season} • Week ${date.week + 1} • Day ${date.day + 1}`;
+}
+
+function render(): void {
+  const world = store.snapshot;
+  const club = world.clubs.find((c) => c.id === world.userClubId);
+  title.textContent = club ? club.name : "HTML5 Football Manager";
+  subtitle.textContent = formatDate(world.date);
+  main.innerHTML = views[activeView](world);
+  if (activeView === "tactics") {
+    drawPitch(document.getElementById("tactics-pitch") as HTMLCanvasElement | null);
+  }
+}
+
+function updateNavigation(): void {
+  nav.querySelectorAll("button").forEach((button) => {
+    const view = button.dataset.view as keyof typeof views | undefined;
+    if (view) {
+      button.classList.toggle("active", view === activeView);
+    }
+  });
+}
+
+const notifications = document.createElement("aside");
+notifications.className = "panel glass";
+notifications.innerHTML = "<div class=\"panel-header\"><span class=\"badge info\">Digest</span><h2>Daily Summary</h2></div><div id=\"notifications\" class=\"panel-body\"><p>No messages yet.</p></div>";
+workspace.append(notifications);
+
+function notify(message: string): void {
+  const container = document.getElementById("notifications");
+  if (!container) return;
+  const list = container.querySelector("ul") ?? document.createElement("ul");
+  if (!list.parentElement) {
+    container.innerHTML = "";
+    container.appendChild(list);
+  }
+  const item = document.createElement("li");
+  item.textContent = message;
+  list.prepend(item);
+}
+
+store.subscribe(render);
+render();
+
+// auto-play opening week to give data
+for (let i = 0; i < 3; i += 1) {
+  const summary = store.dispatch({ type: "ADVANCE_DAY" });
+  summary?.messages.forEach((message) => notify(message));
+}
+render();

--- a/src/styles.css
+++ b/src/styles.css
@@ -892,3 +892,118 @@ body {
     text-align: left;
   }
 }
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  background: rgba(7, 11, 21, 0.55);
+  backdrop-filter: blur(18px);
+  z-index: 1000;
+}
+
+.modal-backdrop.hidden {
+  display: none;
+}
+
+.modal {
+  width: min(920px, 95vw);
+  max-height: 90vh;
+  overflow-y: auto;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background: var(--surface-alt);
+}
+
+.modal-footer {
+  margin-top: 8px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.league-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.league-list .league-option {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--veil-2);
+  color: inherit;
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
+}
+
+.league-list .league-option.active,
+.league-list .league-option:hover {
+  border-color: rgba(var(--accent-rgb), 0.45);
+  background: rgba(var(--accent-rgb), 0.12);
+  transform: translateY(-2px);
+}
+
+.club-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.club-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--veil-1);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.club-card:hover,
+.club-card.active {
+  border-color: rgba(var(--accent-rgb), 0.5);
+  box-shadow: 0 18px 35px rgba(var(--accent-rgb), 0.12);
+  transform: translateY(-4px);
+}
+
+.club-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.club-card .badge {
+  background: rgba(var(--accent-rgb), 0.16);
+  color: var(--accent);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.club-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.club-meta span {
+  display: inline-block;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -212,6 +212,17 @@ body {
   background: var(--veil-2);
 }
 
+.toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.toolbar select {
+  min-width: 220px;
+}
+
 .workspace {
   grid-area: workspace;
   display: grid;
@@ -882,6 +893,14 @@ body {
   .controls button,
   .controls select {
     flex: 1 1 auto;
+  }
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .toolbar select {
+    min-width: 0;
+    width: 100%;
   }
   .scoreboard {
     grid-template-columns: 1fr;

--- a/src/styles.css
+++ b/src/styles.css
@@ -993,6 +993,17 @@ body {
   transition: transform 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
 }
 
+.club-card.create {
+  border-style: dashed;
+  border-color: rgba(var(--accent-rgb), 0.4);
+  background: rgba(var(--accent-rgb), 0.08);
+  color: var(--accent);
+}
+
+.club-card.create:hover {
+  background: rgba(var(--accent-rgb), 0.14);
+}
+
 .club-card:hover,
 .club-card.active {
   border-color: rgba(var(--accent-rgb), 0.5);
@@ -1025,4 +1036,84 @@ body {
 
 .club-meta span {
   display: inline-block;
+}
+
+.custom-club-panel {
+  position: relative;
+}
+
+.custom-club-panel.hidden {
+  display: none;
+}
+
+.custom-club-form {
+  display: grid;
+  gap: 14px;
+  padding: 12px;
+  border: 1px solid rgba(var(--accent-rgb), 0.2);
+  border-radius: var(--radius-lg);
+  background: rgba(var(--background-rgb), 0.7);
+  backdrop-filter: blur(26px);
+}
+
+.custom-club-form .muted-text {
+  margin-top: -4px;
+}
+
+.custom-club-form .modal-footer {
+  margin-top: 4px;
+  justify-content: space-between;
+}
+
+.field,
+.field-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+}
+
+.field-inline input {
+  max-width: 120px;
+}
+
+.field span,
+.field-inline span {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.field input,
+.field select,
+.field-inline input,
+.field-inline select {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: inherit;
+}
+
+.field.colors {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.field.colors label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.field.colors input[type="color"] {
+  width: 100%;
+  height: 44px;
+  padding: 0;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(var(--accent-rgb), 0.35);
+  background: transparent;
+  cursor: pointer;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -740,6 +740,105 @@ body {
   color: var(--text-muted);
 }
 
+.inline-form {
+  display: grid;
+  gap: 12px;
+}
+
+.inline-form label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.input-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.input-row input,
+.input-row select {
+  flex: 1 1 160px;
+  border: 1px solid rgba(var(--border-rgb), 0.4);
+  background: rgba(var(--surface-rgb), 0.65);
+  color: var(--text-primary);
+  border-radius: 12px;
+  padding: 10px 14px;
+}
+
+.budget-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.budget-tile {
+  padding: 18px;
+  border-radius: 20px;
+  background: rgba(var(--surface-rgb), 0.55);
+  border: 1px solid rgba(var(--border-rgb), 0.35);
+  display: grid;
+  gap: 6px;
+}
+
+.budget-tile span {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.budget-tile strong {
+  font-size: 1.3rem;
+  color: var(--text-primary);
+}
+
+.fixtures-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.fixtures-list li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 16px;
+  background: rgba(var(--surface-rgb), 0.55);
+  border: 1px solid rgba(var(--border-rgb), 0.35);
+}
+
+.fixtures-list strong {
+  font-size: 0.95rem;
+}
+
+.transfers-table .input-row input {
+  max-width: 140px;
+}
+
+.data-table.compact th,
+.data-table.compact td {
+  padding: 8px 10px;
+}
+
+.standings-table tr.highlight {
+  background: rgba(var(--accent-rgb), 0.12);
+}
+
+.form-seq {
+  display: inline-flex;
+  gap: 6px;
+  font-family: var(--mono);
+  letter-spacing: 0.1em;
+}
+
 @media (max-width: 1200px) {
   .shell {
     grid-template-columns: 220px minmax(0, 1fr);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,795 @@
+:root {
+  color-scheme: light;
+  --bg-1: #f7f9fc;
+  --bg-2: #e9eef9;
+  --surface: rgba(255, 255, 255, 0.78);
+  --surface-alt: rgba(255, 255, 255, 0.94);
+  --border: rgba(15, 23, 42, 0.08);
+  --border-strong: rgba(15, 23, 42, 0.14);
+  --veil-1: rgba(15, 23, 42, 0.02);
+  --veil-2: rgba(15, 23, 42, 0.04);
+  --veil-3: rgba(15, 23, 42, 0.06);
+  --veil-4: rgba(15, 23, 42, 0.08);
+  --veil-5: rgba(15, 23, 42, 0.12);
+  --veil-6: rgba(15, 23, 42, 0.18);
+  --overlay-contrast: rgba(15, 23, 42, 0.14);
+  --overlay-contrast-strong: rgba(15, 23, 42, 0.2);
+  --overlay-contrast-heavy: rgba(15, 23, 42, 0.28);
+  --accent: #2563eb;
+  --accent-rgb: 37, 99, 235;
+  --accent-soft: rgba(var(--accent-rgb), 0.18);
+  --accent-glow: rgba(var(--accent-rgb), 0.35);
+  --accent-secondary-rgb: 14, 165, 233;
+  --text: #0f172a;
+  --text-muted: #64748b;
+  --shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+  --shadow-inset-strong: inset 0 0 40px rgba(15, 23, 42, 0.22);
+  --positive-rgb: 22, 163, 74;
+  --warning-rgb: 217, 119, 6;
+  --danger-rgb: 220, 38, 38;
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 8px;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --bg-1: #070b15;
+  --bg-2: #101b33;
+  --surface: rgba(17, 33, 54, 0.72);
+  --surface-alt: rgba(17, 33, 54, 0.9);
+  --border: rgba(148, 163, 184, 0.12);
+  --border-strong: rgba(148, 163, 184, 0.22);
+  --veil-1: rgba(255, 255, 255, 0.02);
+  --veil-2: rgba(255, 255, 255, 0.04);
+  --veil-3: rgba(255, 255, 255, 0.06);
+  --veil-4: rgba(255, 255, 255, 0.08);
+  --veil-5: rgba(255, 255, 255, 0.12);
+  --veil-6: rgba(255, 255, 255, 0.18);
+  --overlay-contrast: rgba(8, 12, 20, 0.35);
+  --overlay-contrast-strong: rgba(8, 12, 20, 0.45);
+  --overlay-contrast-heavy: rgba(8, 12, 20, 0.6);
+  --accent: #60a5fa;
+  --accent-rgb: 96, 165, 250;
+  --accent-soft: rgba(var(--accent-rgb), 0.22);
+  --accent-glow: rgba(var(--accent-rgb), 0.45);
+  --accent-secondary-rgb: 129, 140, 248;
+  --text: #f8fafc;
+  --text-muted: #9caecb;
+  --shadow: 0 24px 60px rgba(10, 14, 25, 0.5);
+  --shadow-inset-strong: inset 0 0 40px rgba(0, 0, 0, 0.45);
+  --positive-rgb: 74, 222, 128;
+  --warning-rgb: 250, 204, 21;
+  --danger-rgb: 248, 113, 113;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(var(--accent-rgb), 0.12), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(var(--accent-secondary-rgb), 0.16), transparent 45%),
+    linear-gradient(140deg, var(--bg-1) 0%, var(--bg-2) 100%);
+  color: var(--text);
+  min-height: 100vh;
+  padding: 0;
+}
+
+.shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  grid-template-rows: 96px 1fr;
+  grid-template-areas:
+    "sidebar topbar"
+    "sidebar workspace";
+  gap: 24px;
+  padding: 32px;
+}
+
+.sidebar {
+  grid-area: sidebar;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.brand-mark {
+  font-size: 1.4rem;
+}
+
+.brand-text {
+  font-size: 0.85rem;
+}
+
+.sidebar button {
+  appearance: none;
+  background: var(--veil-2);
+  color: inherit;
+  border: 1px solid transparent;
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
+}
+
+.sidebar button.active,
+.sidebar button:hover {
+  background: rgba(var(--accent-rgb), 0.12);
+  border-color: rgba(var(--accent-rgb), 0.4);
+  transform: translateX(4px);
+}
+
+.topbar {
+  grid-area: topbar;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.glass {
+  backdrop-filter: blur(18px);
+  background: var(--surface);
+}
+
+.title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.page-title {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.page-subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.controls {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.controls button,
+.controls select {
+  padding: 10px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--veil-2);
+  color: inherit;
+  font-weight: 600;
+}
+
+.controls button.ghost {
+  background: var(--veil-1);
+}
+
+.controls button.primary {
+  background: var(--accent);
+  color: #f8fafc;
+  border: none;
+  box-shadow: 0 10px 25px var(--accent-glow);
+}
+
+.controls button:hover {
+  border-color: var(--border-strong);
+}
+
+.controls button.ghost:hover {
+  background: var(--veil-2);
+}
+
+.workspace {
+  grid-area: workspace;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 24px;
+  align-items: start;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.panel {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+}
+
+.panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.panel-header h2 {
+  margin: 0;
+}
+
+.panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel-body ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel-body li {
+  background: var(--veil-2);
+  padding: 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--veil-3);
+}
+
+.card {
+  background: var(--surface-alt);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  padding: 28px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.hero {
+  flex-direction: row;
+  align-items: center;
+  gap: 32px;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: auto -30% -50% auto;
+  width: 340px;
+  height: 340px;
+  background: radial-gradient(circle, rgba(var(--accent-rgb), 0.25), transparent 70%);
+  transform: rotate(25deg);
+  pointer-events: none;
+}
+
+.hero-text {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.hero-text h2 {
+  margin: 0;
+  font-size: 2.1rem;
+}
+
+.hero-text p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--veil-4);
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.pill.muted {
+  background: var(--veil-5);
+  color: var(--text-muted);
+}
+
+.hero-stats {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 18px;
+}
+
+.hero-metric {
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--veil-4);
+  background: var(--overlay-contrast);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hero-metric span {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+}
+
+.hero-metric strong {
+  font-size: 1.6rem;
+}
+
+.fixture-card .fixture {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  gap: 20px;
+  text-align: center;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--veil-4);
+  background: var(--overlay-contrast-strong);
+}
+
+.fixture .club h3 {
+  margin: 12px 0 0;
+}
+
+.fixture .vs {
+  font-size: 1.1rem;
+  letter-spacing: 0.3em;
+  color: var(--text-muted);
+}
+
+.results-list,
+.inbox-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.results-list li,
+.inbox-list li {
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--veil-3);
+  background: var(--veil-2);
+}
+
+.result-match {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.95rem;
+}
+
+.score-pill {
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(var(--accent-rgb), 0.16);
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.inbox-list li {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.data-table thead th {
+  text-align: left;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--veil-5);
+}
+
+.data-table tbody td {
+  padding: 14px 0;
+  border-bottom: 1px solid var(--veil-3);
+  vertical-align: middle;
+}
+
+.data-table tbody tr:hover {
+  background: var(--veil-1);
+}
+
+.player-cell {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(var(--accent-rgb), 0.18);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+
+.player-cell strong {
+  display: block;
+}
+
+.player-cell small {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stat-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(var(--accent-rgb), 0.14);
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.meter {
+  position: relative;
+  height: 6px;
+  width: 120px;
+  border-radius: 999px;
+  background: var(--veil-5);
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+
+.meter::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--value, 0) * 1%);
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.6), rgba(148, 163, 184, 0.95));
+}
+
+.meter.positive::after {
+  background: linear-gradient(90deg, rgba(var(--accent-rgb), 0.4), rgba(var(--accent-rgb), 1));
+}
+
+.muted-text {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.tactics-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 18px;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--veil-5);
+  background: var(--overlay-contrast);
+}
+
+.control select,
+.control input[type="range"] {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--veil-5);
+  background: var(--overlay-contrast-heavy);
+  color: inherit;
+}
+
+.control input[type="range"] {
+  appearance: none;
+  height: 4px;
+  padding: 0;
+}
+
+.control input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: none;
+  cursor: pointer;
+}
+
+.control input[type="range"]::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: none;
+  cursor: pointer;
+}
+
+.pitch {
+  width: 100%;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--veil-5);
+  box-shadow: var(--shadow-inset-strong);
+}
+
+.match-card .match-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 18px;
+}
+
+.match-stat {
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--veil-4);
+  background: var(--overlay-contrast);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.match-stat .label {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.match-stat .values {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.scoreboard {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  text-align: center;
+  background: radial-gradient(circle at 50% 50%, rgba(var(--accent-rgb), 0.16), var(--overlay-contrast-strong));
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--veil-5);
+}
+
+.scoreboard .team {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.team-name {
+  font-size: 1rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.team-score {
+  font-size: 2.6rem;
+  font-weight: 700;
+}
+
+.score-divider {
+  font-size: 0.9rem;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.timeline li {
+  display: grid;
+  grid-template-columns: 60px 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--veil-3);
+  background: var(--veil-1);
+}
+
+.timeline .minute {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(var(--accent-rgb), 0.18);
+  font-weight: 600;
+}
+
+.timeline .empty {
+  grid-template-columns: 1fr;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--veil-5);
+  color: var(--text-muted);
+}
+
+.badge.info {
+  background: rgba(var(--accent-secondary-rgb), 0.18);
+  color: #60a5fa;
+}
+
+.badge.success {
+  background: rgba(var(--accent-rgb), 0.18);
+  color: var(--accent);
+}
+
+.badge.warning {
+  background: rgba(var(--warning-rgb), 0.18);
+  color: #facc15;
+}
+
+.badge.danger {
+  background: rgba(var(--danger-rgb), 0.18);
+  color: #f87171;
+}
+
+.empty {
+  text-align: center;
+  color: var(--text-muted);
+}
+
+@media (max-width: 1200px) {
+  .shell {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+  .workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .panel {
+    order: -1;
+  }
+}
+
+@media (max-width: 920px) {
+  .shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
+    grid-template-areas:
+      "topbar"
+      "workspace"
+      "sidebar";
+    padding: 24px 18px 48px;
+  }
+  .sidebar {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+  .sidebar button {
+    flex: 1 1 120px;
+  }
+  .workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .controls {
+    width: 100%;
+    justify-content: stretch;
+  }
+  .controls button,
+  .controls select {
+    flex: 1 1 auto;
+  }
+  .scoreboard {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .timeline li {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+}

--- a/src/types/zustand.d.ts
+++ b/src/types/zustand.d.ts
@@ -1,0 +1,16 @@
+import type { StateCreator, StoreApi } from "zustand";
+
+declare module "zustand/vanilla" {
+  export * from "zustand";
+  export function createStore<TState>(initializer: StateCreator<TState, [], []>): StoreApi<TState>;
+}
+
+declare module "zustand/middleware/immer" {
+  import type { StateCreator } from "zustand";
+
+  export function immer<TState extends object>(
+    initializer: StateCreator<TState, [["zustand/immer", never], [], []]>
+  ): StateCreator<TState, [["zustand/immer", never], [], []]>;
+
+  export default immer;
+}

--- a/src/ui/components/pitch.ts
+++ b/src/ui/components/pitch.ts
@@ -1,0 +1,37 @@
+export function drawPitch(canvas: HTMLCanvasElement | null): void {
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const { width, height } = canvas;
+  ctx.fillStyle = "#0b5d23";
+  ctx.fillRect(0, 0, width, height);
+  ctx.strokeStyle = "#ffffff";
+  ctx.lineWidth = 2;
+  ctx.strokeRect(20, 20, width - 40, height - 40);
+  ctx.beginPath();
+  ctx.moveTo(width / 2, 20);
+  ctx.lineTo(width / 2, height - 20);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(width / 2, height / 2, 60, 0, Math.PI * 2);
+  ctx.stroke();
+  drawBox(ctx, 20, height / 2 - 70, 80, 140);
+  drawBox(ctx, width - 100, height / 2 - 70, 80, 140);
+  ctx.beginPath();
+  ctx.arc(20 + 40, height / 2, 12, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(width - 60, height / 2, 12, 0, Math.PI * 2);
+  ctx.stroke();
+}
+
+function drawBox(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number
+) {
+  ctx.strokeRect(x, y, width, height);
+  ctx.strokeRect(x, y + 30, width, height - 60);
+}

--- a/src/ui/screens/dashboard.ts
+++ b/src/ui/screens/dashboard.ts
@@ -1,0 +1,185 @@
+import type { World } from "@app/world";
+import type { Fixture } from "@domain/match/types";
+
+function formatDate(date: World["date"]): string {
+  return `Season ${date.season} • Week ${date.week + 1} • Day ${date.day + 1}`;
+}
+
+function nextFixture(world: World): Fixture | undefined {
+  return world.fixtures.find((fixture) => !fixture.played);
+}
+
+export function renderDashboard(world: World): string {
+  const fixture = nextFixture(world);
+  const inboxPreview = world.inbox.slice(0, 4);
+  const recentResults = world.results.slice(0, 4);
+  const club = world.clubs.find((c) => c.id === world.userClubId);
+  const league = world.leagues.find((l) => l.id === club?.leagueId);
+  const fixturesById = new Map(world.fixtures.map((f) => [f.id, f] as const));
+
+  return `
+    <section class="card hero">
+      <div class="hero-text">
+        <span class="eyebrow">Today</span>
+        <h2>${club?.name ?? "HTML5 Football Manager"}</h2>
+        <p>${formatDate(world.date)}</p>
+        <div class="hero-meta">
+          ${league ? `<span class="pill">${league.name}</span>` : ""}
+          <span class="pill">${world.clubs.length} clubs</span>
+          <span class="pill">${world.players.length} players</span>
+        </div>
+      </div>
+      <div class="hero-stats">
+        ${renderSnapshotMetric("Form", formatForm(world.results, fixturesById, club?.id ?? ""))}
+        ${renderSnapshotMetric(
+          "Goal Difference",
+          goalDifference(world.results, fixturesById, club?.id ?? "")
+        )}
+        ${renderSnapshotMetric(
+          "Matches Played",
+          `${matchesPlayed(world.results, fixturesById, club?.id ?? "")}`
+        )}
+      </div>
+    </section>
+    <section class="card fixture-card">
+      <div class="section-heading">
+        <span class="eyebrow">Next Fixture</span>
+        <h2>On the horizon</h2>
+      </div>
+      ${fixture ? renderFixture(world, fixture) : "<p class=\"empty\">No upcoming fixtures scheduled.</p>"}
+    </section>
+    <section class="card results-card">
+      <div class="section-heading">
+        <span class="eyebrow">Recent Results</span>
+        <h2>Match log</h2>
+      </div>
+      ${
+        recentResults.length
+          ? renderResults(world, recentResults, fixturesById)
+          : "<p class=\"empty\">No matches played yet.</p>"
+      }
+    </section>
+    <section class="card inbox-card">
+      <div class="section-heading">
+        <span class="eyebrow">Inbox</span>
+        <h2>Latest notes</h2>
+      </div>
+      <ul class="inbox-list">
+        ${inboxPreview.length ? inboxPreview.map((message) => `<li>${message}</li>`).join("") : "<li>No new mail.</li>"}
+      </ul>
+    </section>
+  `;
+}
+
+function renderSnapshotMetric(label: string, value: string): string {
+  return `
+    <div class="hero-metric">
+      <span>${label}</span>
+      <strong>${value}</strong>
+    </div>
+  `;
+}
+
+function renderFixture(world: World, fixture: Fixture): string {
+  const home = world.clubs.find((club) => club.id === fixture.homeId);
+  const away = world.clubs.find((club) => club.id === fixture.awayId);
+  return `
+    <div class="fixture">
+      <div class="club home">
+        <span class="badge">Home</span>
+        <h3>${home?.name ?? "Unknown"}</h3>
+      </div>
+      <div class="vs">VS</div>
+      <div class="club away">
+        <span class="badge">Away</span>
+        <h3>${away?.name ?? "Unknown"}</h3>
+      </div>
+    </div>
+  `;
+}
+
+function renderResults(
+  world: World,
+  matches: World["results"],
+  fixturesById: Map<Fixture["id"], Fixture>
+): string {
+  return `
+    <ul class="results-list">
+      ${matches
+        .map((match) => {
+          const fixture = fixturesById.get(match.fixtureId) ?? world.fixtures.find((f) => f.id === match.fixtureId);
+          const home = world.clubs.find((club) => club.id === fixture?.homeId)?.shortName ?? "Home";
+          const away = world.clubs.find((club) => club.id === fixture?.awayId)?.shortName ?? "Away";
+          return `
+            <li>
+              <div class="result-match">
+                <strong>${home}</strong>
+                <span class="score-pill">${match.score.home} - ${match.score.away}</span>
+                <strong>${away}</strong>
+              </div>
+            </li>
+          `;
+        })
+        .join("")}
+    </ul>
+  `;
+}
+
+function formatForm(
+  results: World["results"],
+  fixturesById: Map<Fixture["id"], Fixture>,
+  clubId: string
+): string {
+  if (!clubId) return "-";
+  const sequence = results
+    .filter((match) => participated(fixturesById, match, clubId))
+    .slice(0, 5)
+    .map((match) => {
+      const fixture = fixturesById.get(match.fixtureId);
+      if (!fixture) return "-";
+      const isHome = fixture.homeId === clubId;
+      const scored = isHome ? match.score.home : match.score.away;
+      const conceded = isHome ? match.score.away : match.score.home;
+      if (scored === conceded) return "D";
+      return scored > conceded ? "W" : "L";
+    })
+    .join(" ");
+  return sequence || "-";
+}
+
+function goalDifference(
+  matches: World["results"],
+  fixturesById: Map<Fixture["id"], Fixture>,
+  clubId: string
+): string {
+  if (!clubId) return "0";
+  const diff = matches.reduce((total, match) => {
+    const fixture = fixturesById.get(match.fixtureId);
+    if (!fixture) return total;
+    if (fixture.homeId !== clubId && fixture.awayId !== clubId) return total;
+    const isHome = fixture.homeId === clubId;
+    const scored = isHome ? match.score.home : match.score.away;
+    const conceded = isHome ? match.score.away : match.score.home;
+    return total + (scored - conceded);
+  }, 0);
+  return diff >= 0 ? `+${diff}` : `${diff}`;
+}
+
+function matchesPlayed(
+  matches: World["results"],
+  fixturesById: Map<Fixture["id"], Fixture>,
+  clubId: string
+): number {
+  if (!clubId) return 0;
+  return matches.filter((match) => participated(fixturesById, match, clubId)).length;
+}
+
+function participated(
+  fixturesById: Map<Fixture["id"], Fixture>,
+  match: World["results"][number],
+  clubId: string
+): boolean {
+  const fixture = fixturesById.get(match.fixtureId);
+  if (!fixture) return false;
+  return fixture.homeId === clubId || fixture.awayId === clubId;
+}

--- a/src/ui/screens/match.ts
+++ b/src/ui/screens/match.ts
@@ -1,15 +1,9 @@
 import type { World } from "@app/world";
+import { upcomingFixtures } from "@app/world";
 
 export function renderMatch(world: World): string {
   const match = world.results[0];
-  if (!match) {
-    return `<section class="card"><p>No match has been played yet.</p></section>`;
-  }
-  const fixture = world.fixtures.find((f) => f.id === match.fixtureId);
-  const homeClub = world.clubs.find((club) => club.id === fixture?.homeId);
-  const awayClub = world.clubs.find((club) => club.id === fixture?.awayId);
-  const homeStats = match.stats.find((s) => s.clubId === fixture?.homeId);
-  const awayStats = match.stats.find((s) => s.clubId === fixture?.awayId);
+  const nextFixtures = upcomingFixtures(world, world.userClubId);
 
   return `
     <section class="card match-card">
@@ -17,58 +11,114 @@ export function renderMatch(world: World): string {
         <span class="eyebrow">Last Result</span>
         <h2>Full-time report</h2>
       </div>
-      ${renderScoreline(homeClub?.name ?? "Home", awayClub?.name ?? "Away", match.score.home, match.score.away)}
-      <div class="match-stats">
-        ${renderMatchStat("Shots", homeStats?.shots ?? 0, awayStats?.shots ?? 0)}
-        ${renderMatchStat("On Target", homeStats?.shotsOnTarget ?? 0, awayStats?.shotsOnTarget ?? 0)}
-        ${renderMatchStat("Possession", formatPossession(homeStats?.possession), formatPossession(awayStats?.possession))}
-      </div>
-      <h3>Timeline</h3>
-      <ul class="timeline">
-        ${match.events.length
-          ? match.events
-              .map((event) => `<li><span class="minute">${event.minute}'</span><span>${event.description}</span></li>`)
-              .join("")
-          : '<li class="empty">No key events recorded.</li>'}
-      </ul>
+      ${match ? renderMatchSummary(world, match) : '<p class="empty">No matches played yet.</p>'}
     </section>
     <section class="card">
       <div class="section-heading">
-        <span class="eyebrow">Ratings</span>
-        <h2>Player impact</h2>
+        <span class="eyebrow">Simulation</span>
+        <h2>Instant result</h2>
       </div>
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th>Player</th>
-            <th>Rating</th>
-            <th>Goals</th>
-            <th>Shots</th>
-            <th>Passes</th>
-            <th>Tackles</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${match.playerStats
-            .slice()
-            .sort((a, b) => b.rating - a.rating)
-            .map((stat) => {
-              const player = world.players.find((p) => p.id === stat.playerId);
-              return `
-                <tr>
-                  <td>${player?.name ?? stat.playerId}</td>
-                  <td><span class="stat-badge">${stat.rating.toFixed(1)}</span></td>
-                  <td>${stat.goals}</td>
-                  <td>${stat.shots}</td>
-                  <td>${stat.passesCompleted}</td>
-                  <td>${stat.tacklesWon}</td>
-                </tr>
-              `;
-            })
-            .join("")}
-        </tbody>
-      </table>
+      ${
+        nextFixtures.length
+          ? `<form id="manual-sim-form" class="inline-form">
+              <label for="manual-sim-select">Upcoming fixture</label>
+              <div class="input-row">
+                <select id="manual-sim-select" required>
+                  ${nextFixtures
+                    .map(
+                      (fixture) =>
+                        `<option value="${fixture.id}">${fixture.homeId === world.userClubId ? "vs " + clubName(world, fixture.awayId) : "at " + clubName(world, fixture.homeId)}</option>`
+                    )
+                    .join("")}
+                </select>
+                <button type="submit" class="primary">Simulate</button>
+              </div>
+            </form>`
+          : '<p class="empty">No fixtures remain to simulate.</p>'
+      }
     </section>
+  `;
+}
+
+export function bindMatchInteractions<T>(
+  container: HTMLElement,
+  helpers: {
+    simulateFixture: (fixtureId: string) => T;
+    handleResult: (result: T) => void;
+    notify: (message: string) => void;
+  }
+): void {
+  const form = container.querySelector<HTMLFormElement>("#manual-sim-form");
+  if (!form) return;
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const select = form.querySelector<HTMLSelectElement>("#manual-sim-select");
+    if (!select || !select.value) {
+      helpers.notify("Select a fixture to simulate.");
+      return;
+    }
+    const result = helpers.simulateFixture(select.value);
+    helpers.handleResult(result);
+  });
+}
+
+function renderMatchSummary(world: World, match: World["results"][number]): string {
+  const fixture = world.fixtures.find((f) => f.id === match.fixtureId);
+  const homeClub = world.clubs.find((club) => club.id === fixture?.homeId);
+  const awayClub = world.clubs.find((club) => club.id === fixture?.awayId);
+  const homeStats = match.stats.find((s) => s.clubId === fixture?.homeId);
+  const awayStats = match.stats.find((s) => s.clubId === fixture?.awayId);
+
+  return `
+    ${renderScoreline(homeClub?.name ?? "Home", awayClub?.name ?? "Away", match.score.home, match.score.away)}
+    <div class="match-stats">
+      ${renderMatchStat("Shots", homeStats?.shots ?? 0, awayStats?.shots ?? 0)}
+      ${renderMatchStat("On Target", homeStats?.shotsOnTarget ?? 0, awayStats?.shotsOnTarget ?? 0)}
+      ${renderMatchStat("Possession", formatPossession(homeStats?.possession), formatPossession(awayStats?.possession))}
+    </div>
+    <h3>Timeline</h3>
+    <ul class="timeline">
+      ${
+        match.events.length
+          ? match.events
+              .map((event) => `<li><span class="minute">${event.minute}'</span><span>${event.description}</span></li>`)
+              .join("")
+          : '<li class="empty">No key events recorded.</li>'
+      }
+    </ul>
+    <h3>Player impact</h3>
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th>Player</th>
+          <th>Rating</th>
+          <th>Goals</th>
+          <th>Shots</th>
+          <th>Passes</th>
+          <th>Tackles</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${match.playerStats
+          .slice()
+          .sort((a, b) => b.rating - a.rating)
+          .map((stat) => {
+            const player = world.players.find((p) => p.id === stat.playerId);
+            return `
+              <tr>
+                <td>${player?.name ?? stat.playerId}</td>
+                <td><span class="stat-badge">${stat.rating.toFixed(1)}</span></td>
+                <td>${stat.goals}</td>
+                <td>${stat.shots}</td>
+                <td>${stat.passesCompleted}</td>
+                <td>${stat.tacklesWon}</td>
+              </tr>
+            `;
+          })
+          .join("")}
+      </tbody>
+    </table>
   `;
 }
 
@@ -102,4 +152,8 @@ function renderMatchStat(label: string, home: number | string, away: number | st
 
 function formatPossession(value: number | undefined): string {
   return value !== undefined ? `${value.toFixed(0)}%` : "-";
+}
+
+function clubName(world: World, id: string): string {
+  return world.clubs.find((club) => club.id === id)?.shortName ?? "Unknown";
 }

--- a/src/ui/screens/match.ts
+++ b/src/ui/screens/match.ts
@@ -2,6 +2,9 @@ import type { World } from "@app/world";
 import { upcomingFixtures } from "@app/world";
 
 export function renderMatch(world: World): string {
+  if (!world.userClubId) {
+    return `<section class="card"><p class="empty">Select a club to view matchday reports.</p></section>`;
+  }
   const match = world.results[0];
   const nextFixtures = upcomingFixtures(world, world.userClubId);
 

--- a/src/ui/screens/match.ts
+++ b/src/ui/screens/match.ts
@@ -1,0 +1,105 @@
+import type { World } from "@app/world";
+
+export function renderMatch(world: World): string {
+  const match = world.results[0];
+  if (!match) {
+    return `<section class="card"><p>No match has been played yet.</p></section>`;
+  }
+  const fixture = world.fixtures.find((f) => f.id === match.fixtureId);
+  const homeClub = world.clubs.find((club) => club.id === fixture?.homeId);
+  const awayClub = world.clubs.find((club) => club.id === fixture?.awayId);
+  const homeStats = match.stats.find((s) => s.clubId === fixture?.homeId);
+  const awayStats = match.stats.find((s) => s.clubId === fixture?.awayId);
+
+  return `
+    <section class="card match-card">
+      <div class="section-heading">
+        <span class="eyebrow">Last Result</span>
+        <h2>Full-time report</h2>
+      </div>
+      ${renderScoreline(homeClub?.name ?? "Home", awayClub?.name ?? "Away", match.score.home, match.score.away)}
+      <div class="match-stats">
+        ${renderMatchStat("Shots", homeStats?.shots ?? 0, awayStats?.shots ?? 0)}
+        ${renderMatchStat("On Target", homeStats?.shotsOnTarget ?? 0, awayStats?.shotsOnTarget ?? 0)}
+        ${renderMatchStat("Possession", formatPossession(homeStats?.possession), formatPossession(awayStats?.possession))}
+      </div>
+      <h3>Timeline</h3>
+      <ul class="timeline">
+        ${match.events.length
+          ? match.events
+              .map((event) => `<li><span class="minute">${event.minute}'</span><span>${event.description}</span></li>`)
+              .join("")
+          : '<li class="empty">No key events recorded.</li>'}
+      </ul>
+    </section>
+    <section class="card">
+      <div class="section-heading">
+        <span class="eyebrow">Ratings</span>
+        <h2>Player impact</h2>
+      </div>
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Player</th>
+            <th>Rating</th>
+            <th>Goals</th>
+            <th>Shots</th>
+            <th>Passes</th>
+            <th>Tackles</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${match.playerStats
+            .slice()
+            .sort((a, b) => b.rating - a.rating)
+            .map((stat) => {
+              const player = world.players.find((p) => p.id === stat.playerId);
+              return `
+                <tr>
+                  <td>${player?.name ?? stat.playerId}</td>
+                  <td><span class="stat-badge">${stat.rating.toFixed(1)}</span></td>
+                  <td>${stat.goals}</td>
+                  <td>${stat.shots}</td>
+                  <td>${stat.passesCompleted}</td>
+                  <td>${stat.tacklesWon}</td>
+                </tr>
+              `;
+            })
+            .join("")}
+        </tbody>
+      </table>
+    </section>
+  `;
+}
+
+function renderScoreline(home: string, away: string, homeScore: number, awayScore: number): string {
+  return `
+    <div class="scoreboard">
+      <div class="team">
+        <span class="team-name">${home}</span>
+        <span class="team-score">${homeScore}</span>
+      </div>
+      <div class="score-divider">vs</div>
+      <div class="team">
+        <span class="team-name">${away}</span>
+        <span class="team-score">${awayScore}</span>
+      </div>
+    </div>
+  `;
+}
+
+function renderMatchStat(label: string, home: number | string, away: number | string): string {
+  return `
+    <div class="match-stat">
+      <span class="label">${label}</span>
+      <div class="values">
+        <span>${home}</span>
+        <span>${away}</span>
+      </div>
+    </div>
+  `;
+}
+
+function formatPossession(value: number | undefined): string {
+  return value !== undefined ? `${value.toFixed(0)}%` : "-";
+}

--- a/src/ui/screens/squad.ts
+++ b/src/ui/screens/squad.ts
@@ -27,13 +27,16 @@ export function renderSquad(world: World): string {
             <th>CA</th>
             <th>Morale</th>
             <th>Condition</th>
+            <th>Wage</th>
+            <th>Value</th>
+            <th>Contract</th>
           </tr>
         </thead>
         <tbody>
           ${players
             .map(
               (player) => {
-                const nationality = player.nationality[0] ?? "";
+                const nationality = player.nationality;
                 return `
                 <tr>
                   <td>
@@ -58,6 +61,9 @@ export function renderSquad(world: World): string {
                     <div class="meter positive" style="--value:${Math.round(player.condition)}"></div>
                     <small>${Math.round(player.condition)}%</small>
                   </td>
+                  <td>£${formatCurrency(player.wage)}/wk</td>
+                  <td>£${formatCurrency(player.value)}</td>
+                  <td>${player.contractExpirySeason}</td>
                 </tr>
               `;
               }
@@ -67,4 +73,8 @@ export function renderSquad(world: World): string {
       </table>
     </section>
   `;
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-GB", { maximumFractionDigits: 0 }).format(value);
 }

--- a/src/ui/screens/squad.ts
+++ b/src/ui/screens/squad.ts
@@ -1,0 +1,70 @@
+import type { World } from "@app/world";
+import type { Player } from "@domain/player/types";
+
+export function renderSquad(world: World): string {
+  const club = world.clubs.find((c) => c.id === world.userClubId);
+  if (!club) {
+    return `<section class="card"><p>No club selected.</p></section>`;
+  }
+
+  const players = club.roster
+    .map((playerId) => world.players.find((player) => player.id === playerId))
+    .filter((player): player is Player => Boolean(player))
+    .sort((a, b) => b.currentAbility - a.currentAbility);
+
+  return `
+    <section class="card squad-card">
+      <div class="section-heading">
+        <span class="eyebrow">Squad Overview</span>
+        <h2>${club.name}</h2>
+      </div>
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Player</th>
+            <th>Positions</th>
+            <th>Age</th>
+            <th>CA</th>
+            <th>Morale</th>
+            <th>Condition</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${players
+            .map(
+              (player) => {
+                const nationality = player.nationality[0] ?? "";
+                return `
+                <tr>
+                  <td>
+                    <div class="player-cell">
+                      <span class="avatar">${player.name.slice(0, 1)}</span>
+                      <div>
+                        <strong>${player.name}</strong>
+                        ${nationality ? `<small>${nationality}</small>` : ""}
+                      </div>
+                    </div>
+                  </td>
+                  <td>${player.positions
+                    .map((pos) => `<span class="pill muted">${pos}</span>`)
+                    .join(" ")}</td>
+                  <td>${player.age.toFixed(0)}</td>
+                  <td><span class="stat-badge">${player.currentAbility}</span></td>
+                  <td>
+                    <div class="meter" style="--value:${Math.round(player.morale)}"></div>
+                    <small>${Math.round(player.morale)}</small>
+                  </td>
+                  <td>
+                    <div class="meter positive" style="--value:${Math.round(player.condition)}"></div>
+                    <small>${Math.round(player.condition)}%</small>
+                  </td>
+                </tr>
+              `;
+              }
+            )
+            .join("")}
+        </tbody>
+      </table>
+    </section>
+  `;
+}

--- a/src/ui/screens/standings.ts
+++ b/src/ui/screens/standings.ts
@@ -1,13 +1,18 @@
-import type { World } from "@app/world";
+import type { StandingsRow, World } from "@app/world";
+import { standingsForLeague } from "@app/world";
 
 export function renderStandings(world: World): string {
-  const standings = world.standings;
+  const targetLeagueId = world.userLeagueId ?? world.leagues[0]?.id ?? null;
+  const league = world.leagues.find((entry) => entry.id === targetLeagueId);
+  const standings = standingsForLeague(world, targetLeagueId);
+  const competitionSummary = `${world.leagues.length} competitions across ${new Set(world.leagues.map((l) => l.nation)).size} nations`;
   return `
     <section class="card">
       <div class="section-heading">
         <span class="eyebrow">Competition</span>
-        <h2>${world.leagues[0]?.name ?? "League table"}</h2>
+        <h2>${league?.name ?? "League table"}</h2>
       </div>
+      <p class="muted-text">${competitionSummary}</p>
       <table class="data-table standings-table">
         <thead>
           <tr>
@@ -25,29 +30,33 @@ export function renderStandings(world: World): string {
           </tr>
         </thead>
         <tbody>
-          ${standings
-            .map((row, index) => {
-              const club = world.clubs.find((entry) => entry.id === row.clubId);
-              const isUser = row.clubId === world.userClubId;
-              return `
-                <tr class="${isUser ? "highlight" : ""}">
-                  <td>${index + 1}</td>
-                  <td>${club?.name ?? row.clubId}</td>
-                  <td>${row.played}</td>
-                  <td>${row.won}</td>
-                  <td>${row.drawn}</td>
-                  <td>${row.lost}</td>
-                  <td>${row.goalsFor}</td>
-                  <td>${row.goalsAgainst}</td>
-                  <td>${row.goalDifference}</td>
-                  <td>${row.points}</td>
-                  <td><span class="form-seq">${row.form.join(" ") || "-"}</span></td>
-                </tr>
-              `;
-            })
-            .join("")}
+          ${renderTableBody(world, standings)}
         </tbody>
       </table>
     </section>
   `;
+}
+
+function renderTableBody(world: World, standings: StandingsRow[]): string {
+  return standings
+    .map((row, index) => {
+      const club = world.clubs.find((entry) => entry.id === row.clubId);
+      const isUser = row.clubId === world.userClubId;
+      return `
+        <tr class="${isUser ? "highlight" : ""}">
+          <td>${index + 1}</td>
+          <td>${club?.name ?? row.clubId}</td>
+          <td>${row.played}</td>
+          <td>${row.won}</td>
+          <td>${row.drawn}</td>
+          <td>${row.lost}</td>
+          <td>${row.goalsFor}</td>
+          <td>${row.goalsAgainst}</td>
+          <td>${row.goalDifference}</td>
+          <td>${row.points}</td>
+          <td><span class="form-seq">${row.form.join(" ") || "-"}</span></td>
+        </tr>
+      `;
+    })
+    .join("");
 }

--- a/src/ui/screens/standings.ts
+++ b/src/ui/screens/standings.ts
@@ -1,0 +1,53 @@
+import type { World } from "@app/world";
+
+export function renderStandings(world: World): string {
+  const standings = world.standings;
+  return `
+    <section class="card">
+      <div class="section-heading">
+        <span class="eyebrow">Competition</span>
+        <h2>${world.leagues[0]?.name ?? "League table"}</h2>
+      </div>
+      <table class="data-table standings-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Club</th>
+            <th>P</th>
+            <th>W</th>
+            <th>D</th>
+            <th>L</th>
+            <th>GF</th>
+            <th>GA</th>
+            <th>GD</th>
+            <th>Pts</th>
+            <th>Form</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${standings
+            .map((row, index) => {
+              const club = world.clubs.find((entry) => entry.id === row.clubId);
+              const isUser = row.clubId === world.userClubId;
+              return `
+                <tr class="${isUser ? "highlight" : ""}">
+                  <td>${index + 1}</td>
+                  <td>${club?.name ?? row.clubId}</td>
+                  <td>${row.played}</td>
+                  <td>${row.won}</td>
+                  <td>${row.drawn}</td>
+                  <td>${row.lost}</td>
+                  <td>${row.goalsFor}</td>
+                  <td>${row.goalsAgainst}</td>
+                  <td>${row.goalDifference}</td>
+                  <td>${row.points}</td>
+                  <td><span class="form-seq">${row.form.join(" ") || "-"}</span></td>
+                </tr>
+              `;
+            })
+            .join("")}
+        </tbody>
+      </table>
+    </section>
+  `;
+}

--- a/src/ui/screens/standings.ts
+++ b/src/ui/screens/standings.ts
@@ -1,16 +1,38 @@
 import type { StandingsRow, World } from "@app/world";
 import { standingsForLeague } from "@app/world";
+import type { ID } from "@core/types";
 
-export function renderStandings(world: World): string {
-  const targetLeagueId = world.userLeagueId ?? world.leagues[0]?.id ?? null;
-  const league = world.leagues.find((entry) => entry.id === targetLeagueId);
-  const standings = standingsForLeague(world, targetLeagueId);
-  const competitionSummary = `${world.leagues.length} competitions across ${new Set(world.leagues.map((l) => l.nation)).size} nations`;
+export function renderStandings(world: World, selectedLeagueId: ID | null): string {
+  const sortedLeagues = [...world.leagues].sort(
+    (a, b) => a.level - b.level || a.name.localeCompare(b.name)
+  );
+  const league =
+    sortedLeagues.find((entry) => entry.id === selectedLeagueId) ?? sortedLeagues[0];
+  if (!league) {
+    return `<section class="card"><p class="empty">No league data available.</p></section>`;
+  }
+
+  const standings = standingsForLeague(world, league.id);
+  const competitionSummary = `${world.leagues.length} competitions across ${new Set(
+    world.leagues.map((l) => l.nation)
+  ).size} nations`;
+
   return `
     <section class="card">
       <div class="section-heading">
         <span class="eyebrow">Competition</span>
-        <h2>${league?.name ?? "League table"}</h2>
+        <h2>${league.name}</h2>
+      </div>
+      <div class="toolbar">
+        <label for="standings-league" class="muted-text">League</label>
+        <select id="standings-league">
+          ${sortedLeagues
+            .map(
+              (entry) =>
+                `<option value="${entry.id}" ${entry.id === league.id ? "selected" : ""}>${entry.name} (Tier ${entry.level}, ${entry.nation})</option>`
+            )
+            .join("")}
+        </select>
       </div>
       <p class="muted-text">${competitionSummary}</p>
       <table class="data-table standings-table">
@@ -59,4 +81,15 @@ function renderTableBody(world: World, standings: StandingsRow[]): string {
       `;
     })
     .join("");
+}
+
+export function bindStandingsInteractions(
+  container: HTMLElement,
+  helpers: { onLeagueChange: (leagueId: ID) => void }
+): void {
+  const select = container.querySelector<HTMLSelectElement>("#standings-league");
+  if (!select) return;
+  select.addEventListener("change", () => {
+    helpers.onLeagueChange(select.value as ID);
+  });
 }

--- a/src/ui/screens/tactics.ts
+++ b/src/ui/screens/tactics.ts
@@ -1,0 +1,64 @@
+import type { World } from "@app/world";
+
+export function renderTactics(world: World): string {
+  const club = world.clubs.find((c) => c.id === world.userClubId);
+  if (!club) return `<section class="card"><p>No tactics available.</p></section>`;
+
+  const instructions = `
+    <div class="tactics-controls">
+      <div class="control">
+        <span class="eyebrow">Formation</span>
+        <div class="field">
+          <select id="formation-select" disabled>
+            ${["4-4-2", "4-3-3", "3-5-2", "4-2-3-1"]
+              .map((formation) => `<option value="${formation}" ${
+                formation === club.tactics.formation ? "selected" : ""
+              }>${formation}</option>`)
+              .join("")}
+          </select>
+        </div>
+      </div>
+      <div class="control">
+        <span class="eyebrow">Mentality</span>
+        <div class="field">
+          <select id="mentality-select" disabled>
+            ${["Cautious", "Balanced", "Positive"]
+              .map((mentality) => `<option value="${mentality}" ${
+                mentality === club.tactics.mentality ? "selected" : ""
+              }>${mentality}</option>`)
+              .join("")}
+          </select>
+        </div>
+      </div>
+      <div class="control">
+        <span class="eyebrow">Tempo</span>
+        <div class="slider"><input type="range" min="0" max="100" value="${club.tactics.tempo}" disabled /></div>
+      </div>
+      <div class="control">
+        <span class="eyebrow">Press</span>
+        <div class="slider"><input type="range" min="0" max="100" value="${club.tactics.press}" disabled /></div>
+      </div>
+    </div>
+  `;
+
+  return `
+    <section class="card tactics-card">
+      <div class="section-heading">
+        <span class="eyebrow">Tactical Identity</span>
+        <h2>Game model</h2>
+      </div>
+      ${instructions}
+      <p class="muted-text">
+        Editing is locked for this slice. The next milestone unlocks interactive role selection,
+        in-possession tweaks, and set-piece blueprints.
+      </p>
+    </section>
+    <section class="card formation-card">
+      <div class="section-heading">
+        <span class="eyebrow">Shape</span>
+        <h2>Formation board</h2>
+      </div>
+      <canvas id="tactics-pitch" class="pitch" width="900" height="420"></canvas>
+    </section>
+  `;
+}

--- a/src/ui/screens/transfers.ts
+++ b/src/ui/screens/transfers.ts
@@ -2,6 +2,9 @@ import type { World } from "@app/world";
 
 export function renderTransfers(world: World): string {
   const club = world.clubs.find((entry) => entry.id === world.userClubId);
+  if (!club) {
+    return `<section class="card"><p class="empty">Select a club to manage transfers.</p></section>`;
+  }
   const listings = world.transferListings.filter((listing) => listing.status !== "Completed");
   const history = world.transferHistory.slice(0, 6);
 
@@ -14,15 +17,15 @@ export function renderTransfers(world: World): string {
       <div class="budget-grid">
         <div class="budget-tile">
           <span>Transfer budget</span>
-          <strong>£${formatCurrency(club?.transferBudget ?? 0)}</strong>
+          <strong>£${formatCurrency(club.transferBudget)}</strong>
         </div>
         <div class="budget-tile">
           <span>Wage budget</span>
-          <strong>£${formatCurrency(club?.wageBudget ?? 0)}/wk</strong>
+          <strong>£${formatCurrency(club.wageBudget)}/wk</strong>
         </div>
         <div class="budget-tile">
           <span>Committed wages</span>
-          <strong>£${formatCurrency(club?.wageCommitment ?? 0)}/wk</strong>
+          <strong>£${formatCurrency(club.wageCommitment)}/wk</strong>
         </div>
       </div>
     </section>

--- a/src/ui/screens/transfers.ts
+++ b/src/ui/screens/transfers.ts
@@ -1,0 +1,130 @@
+import type { World } from "@app/world";
+
+export function renderTransfers(world: World): string {
+  const club = world.clubs.find((entry) => entry.id === world.userClubId);
+  const listings = world.transferListings.filter((listing) => listing.status !== "Completed");
+  const history = world.transferHistory.slice(0, 6);
+
+  return `
+    <section class="card">
+      <div class="section-heading">
+        <span class="eyebrow">Budgets</span>
+        <h2>Financial outlook</h2>
+      </div>
+      <div class="budget-grid">
+        <div class="budget-tile">
+          <span>Transfer budget</span>
+          <strong>£${formatCurrency(club?.transferBudget ?? 0)}</strong>
+        </div>
+        <div class="budget-tile">
+          <span>Wage budget</span>
+          <strong>£${formatCurrency(club?.wageBudget ?? 0)}/wk</strong>
+        </div>
+        <div class="budget-tile">
+          <span>Committed wages</span>
+          <strong>£${formatCurrency(club?.wageCommitment ?? 0)}/wk</strong>
+        </div>
+      </div>
+    </section>
+    <section class="card">
+      <div class="section-heading">
+        <span class="eyebrow">Marketplace</span>
+        <h2>Transfer targets</h2>
+      </div>
+      ${
+        listings.length
+          ? `<table class="data-table transfers-table">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>Club</th>
+                  <th>Value</th>
+                  <th>Asking price</th>
+                  <th>Bid</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${listings
+                  .map((listing) => renderListingRow(world, listing))
+                  .join("")}
+              </tbody>
+            </table>`
+          : '<p class="empty">No players are currently available.</p>'
+      }
+    </section>
+    <section class="card">
+      <div class="section-heading">
+        <span class="eyebrow">Recent activity</span>
+        <h2>Completed deals</h2>
+      </div>
+      ${
+        history.length
+          ? `<ul class="timeline">${history
+              .map((entry) => {
+                const player = world.players.find((p) => p.id === entry.playerId);
+                const seller = world.clubs.find((c) => c.id === entry.fromClubId);
+                const buyer = world.clubs.find((c) => c.id === entry.toClubId);
+                return `<li><span class="minute">£${formatCurrency(entry.fee)}</span><span>${player?.name ?? "Player"} → ${buyer?.shortName ?? "???"} (${seller?.shortName ?? "???"})</span></li>`;
+              })
+              .join("")}</ul>`
+          : '<p class="empty">No recent transfers.</p>'
+      }
+    </section>
+  `;
+}
+
+export function bindTransferInteractions(
+  container: HTMLElement,
+  helpers: {
+    makeTransferBid: (playerId: string, offer: number) => string;
+    notify: (message: string) => void;
+  }
+): void {
+  container.querySelectorAll<HTMLButtonElement>("[data-transfer-action]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const playerId = button.dataset.playerId;
+      const inputId = button.dataset.inputId;
+      if (!playerId || !inputId) return;
+      const input = container.querySelector<HTMLInputElement>(`#${inputId}`);
+      if (!input) return;
+      const offer = Number.parseInt(input.value.replace(/[^0-9]/g, ""), 10);
+      if (!Number.isFinite(offer) || offer <= 0) {
+        helpers.notify("Enter a valid offer amount.");
+        return;
+      }
+      const response = helpers.makeTransferBid(playerId, offer);
+      helpers.notify(response);
+    });
+  });
+}
+
+function renderListingRow(world: World, listing: World["transferListings"][number]): string {
+  const player = world.players.find((p) => p.id === listing.playerId);
+  const club = world.clubs.find((c) => c.id === listing.fromClubId);
+  const inputId = `offer-${listing.playerId}`;
+  return `
+    <tr>
+      <td>
+        <div class="player-cell">
+          <strong>${player?.name ?? "Unknown"}</strong>
+          <span>${player?.positions.join(", ") ?? ""}</span>
+        </div>
+      </td>
+      <td>${club?.shortName ?? "-"}</td>
+      <td>£${formatCurrency(player?.value ?? 0)}</td>
+      <td>£${formatCurrency(listing.askingPrice)}</td>
+      <td>
+        <div class="input-row">
+          <input id="${inputId}" type="number" min="100000" step="500000" value="${listing.askingPrice}" />
+          <button type="button" class="primary" data-transfer-action data-player-id="${listing.playerId}" data-input-id="${inputId}">
+            Submit bid
+          </button>
+        </div>
+      </td>
+    </tr>
+  `;
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-GB", { maximumFractionDigits: 0 }).format(value);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"],
+    "baseUrl": "./src",
+    "paths": {
+      "@app/*": ["app/*"],
+      "@core/*": ["core/*"],
+      "@data/*": ["data/*"],
+      "@domain/*": ["domain/*"],
+      "@engine/*": ["engine/*"],
+      "@ui/*": ["ui/*"],
+      "@persistence/*": ["persistence/*"]
+    }
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vite";
+import { fileURLToPath, URL } from "node:url";
+
+export default defineConfig({
+  root: ".",
+  resolve: {
+    alias: {
+      "@app": fileURLToPath(new URL("./src/app", import.meta.url)),
+      "@core": fileURLToPath(new URL("./src/core", import.meta.url)),
+      "@data": fileURLToPath(new URL("./src/data", import.meta.url)),
+      "@domain": fileURLToPath(new URL("./src/domain", import.meta.url)),
+      "@engine": fileURLToPath(new URL("./src/engine", import.meta.url)),
+      "@ui": fileURLToPath(new URL("./src/ui", import.meta.url)),
+      "@persistence": fileURLToPath(new URL("./src/persistence", import.meta.url))
+    }
+  },
+  server: {
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- Reworked the single-page shell with a glassmorphic sidebar, top bar, and notification digest to frame navigation and controls.
- Restyled the dashboard, squad, tactics, and matchday screens with hero metrics, fixture cards, progress meters, and a richer match report.
- Expanded the global stylesheet with gradients, cards, scoreboards, and responsive tweaks to support the new aesthetic.
- Introduced coordinated light and dark color palettes with a persistent theme toggle and refreshed surface tokens across the UI.
- Added a local development guide and linked quick-start instructions in the README.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a31c5b7c8333b02df52eec90a180